### PR TITLE
Add doc about not_ and warn about parentheses

### DIFF
--- a/api/python/index.md
+++ b/api/python/index.md
@@ -1590,7 +1590,7 @@ bool.not_() &rarr; bool
 {% endapibody %}
 Compute the logical inverse (not).
 
-__Example:__ This query returns `False` since not `True` is `False`.
+__Example:__ Not true is false.
 
 ```py
 (~r.expr(True)).run(conn)

--- a/api/python/math-and-logic/not.md
+++ b/api/python/math-and-logic/not.md
@@ -18,7 +18,7 @@ bool.not_() &rarr; bool
 # Description #
 Compute the logical inverse (not).
 
-__Example:__ This query returns `False` since not `True` is `False`.
+__Example:__ Not true is false.
 
 ```py
 (~r.expr(True)).run(conn)


### PR DESCRIPTION
@atnnn would you mind taking a look?

`_not` was added here: https://github.com/rethinkdb/rethinkdb/issues/1329
And we don't have any doc about it.

Related issue: https://github.com/rethinkdb/docs/issues/16
