### PR TITLE
Sort the result of os.listdir to make the results deterministic

### DIFF
--- a/_scripts/dataexplorer.py
+++ b/_scripts/dataexplorer.py
@@ -111,7 +111,7 @@ def add_io_field(file_name, result):
 
 def browse_files(base, result):
     subdirlist = []
-    for item in os.listdir(base):
+    for item in sorted(os.listdir(base)):
         if item[0] != '.' and item not in IGNORED_FILES:
             full_path = os.path.join(base, item)
             if os.path.isfile(full_path):

--- a/_scripts/gen_python.py
+++ b/_scripts/gen_python.py
@@ -147,7 +147,7 @@ def add_doc(file_name, result):
 # Browse all the docs
 def browse_files(base, result):
     subdirlist = []
-    for item in os.listdir(base):
+    for item in sorted(os.listdir(base)):
         if item[0] != '.' and item not in IGNORED_FILES:
             full_path = os.path.join(base, item)
             if os.path.isfile(full_path):


### PR DESCRIPTION
Different calls to listdir may return the files in a different order. This caused diffs of different versions of the py_docs.json file to be useless.

@neumino can you please merge this into your branch and rebuild rethinkdb/michel_md_docs:docs/rql/py_docs.json ?
