### PR TITLE
Update docs for r.connect

### DIFF
--- a/api/javascript/accessing-rql/connect.md
+++ b/api/javascript/accessing-rql/connect.md
@@ -40,7 +40,7 @@ r.connect({
     host: "localhost",
     port: 28015,
     db: "marvel",
-    authKey: "level8password"
+    authKey: "hunter2"
 }, function(err, conn) { ... })
 ```
 

--- a/api/javascript/index.md
+++ b/api/javascript/index.md
@@ -49,7 +49,7 @@ r.connect({
     host: "localhost",
     port: 28015,
     db: "marvel",
-    authKey: "level8password"
+    authKey: "hunter2"
 }, function(err, conn) { ... })
 ```
 

--- a/api/python/accessing-rql/connect.md
+++ b/api/python/accessing-rql/connect.md
@@ -35,7 +35,7 @@ If the connection cannot be established, a `RqlDriverError` exception will be th
 __Example:__ Opens a new connection to the database.
 
 ```py
-conn = r.connect(host="localhost", port="28015", db="marvel", auth_key="level8password")
+conn = r.connect(host="localhost", port="28015", db="marvel", auth_key="hunter2")
 ```
 
 __Example:__ Opens a new connection to the database by just specifying the host.

--- a/api/python/index.md
+++ b/api/python/index.md
@@ -49,7 +49,7 @@ __Example:__ Opens a new connection to the database.
 
 ```py
 conn = r.connect(host="localhost", port="28015", db="marvel",
-    auth_key="level8password")
+    auth_key="hunter2")
 ```
 
 [Read more about this command &rarr;](connect/)

--- a/api/ruby/accessing-rql/connect.md
+++ b/api/ruby/accessing-rql/connect.md
@@ -33,7 +33,7 @@ If the connection cannot be established, a `RqlDriverError` exception will be th
 __Example:__ Opens a new connection to the database.
 
 ```rb
-conn = r.connect(:host => 'localhost', :port => 28015, :db => 'marvel', :auth_key => 'level8password')
+conn = r.connect(:host => 'localhost', :port => 28015, :db => 'marvel', :auth_key => 'hunter2')
 ```
 
 

--- a/api/ruby/index.md
+++ b/api/ruby/index.md
@@ -46,7 +46,7 @@ __Example:__ Opens a new connection to the database.
 
 ```rb
 conn = r.connect(:host => 'localhost', :port => 28015, :db => 'marvel',
-    :auth_key => 'level8password')
+    :auth_key => 'hunter2')
 ```
 
 [Read more about this command &rarr;](connect/)


### PR DESCRIPTION
Related to https://github.com/rethinkdb/docs/issues/52
- Add the syntax `r.connect("host")`
- Add a little more information about errors in JavaScript (some are thrown and not passed to the callback).
- Add the timeout argument

@atnnn would you mind taking a look at it?
