### PR TITLE
Mismatched link for javascript table command

### DIFF
--- a/api/javascript/index.md
+++ b/api/javascript/index.md
@@ -612,7 +612,7 @@ __Example:__ Return all documents in the table 'marvel' of the default database.
 r.table('marvel').run(conn, callback)
 ```
 
-[Read more about this command &rarr;](replace/)
+[Read more about this command &rarr;](table/)
 
 ## [get](get/) ##
 


### PR DESCRIPTION
The link for the javascript command `table` points to `replace/` instead of the proper `table/`
