### PR TITLE
close python code block

### DIFF
--- a/api/python/writing-data/insert.md
+++ b/api/python/writing-data/insert.md
@@ -60,6 +60,7 @@ r.table('marvel').insert(
     { 'superhero': 'Iron Man', 'superpower': 'Arc Reactor' },
     upsert=True
 ).run(conn)
+```
 
 
 __Example:__ Get back a copy of the new row, this is useful if you've done an upsert or generated an ID.


### PR DESCRIPTION
Just closing the block.

![screenshot 2013-11-25 23 57 16](https://f.cloud.github.com/assets/2801090/1619959/faa66a74-5667-11e3-86e7-0e12e964917e.png)

I think you might be missing a config file for Jekyll in the repo. It's not possible to generate the docs locally because the custom tags aren't recognized.
