### PR TITLE
Update instructions for CentOS

### DIFF
--- a/1-get-started/install/centos.md
+++ b/1-get-started/install/centos.md
@@ -83,7 +83,7 @@ Kick off the build process:
 
 ```
 cd rethinkdb
-./configure --fetch protoc
+./configure --fetch protoc --fetch npm --fetch tcmalloc_minimal
 make
 ```
 


### PR DESCRIPTION
For CentOS

I'm not sure if using the Epel repository is something common for CentOS users, and since we have a magic (and awesome) `--fetch` flag, I also wrote instructions without the Epel repo.

Running `./configure --fetch protoc` will also fetch node, npm and gperftools.

Instructions tested on CentOS 6.5. Ping @atnnn 
