### PR TITLE
Update instructions to build from source for Ubuntu

### DIFF
--- a/1-get-started/build.md
+++ b/1-get-started/build.md
@@ -6,64 +6,47 @@ docs_active: install
 permalink: docs/build/
 ---
 
-There are two ways to get the RethinkDB source code:
+These are generic build instructions. Take a look at the [install page](/docs/install/)
+if you are looking for a specific platform.
 
-* You can download a prepacked source code distribution
-* You can clone the RethinkDB git repository
+# Building from source #
 
-# Building from a prepackaged source distribution #
-
-## Get the source code ##
-
-To start building RethinkDB from source, first download and extract the RethinkDB source distribution:
-
-```bash
-wget http://download.rethinkdb.com/dist/rethinkdb-{{site.version.major}}.{{site.version.minor}}.tgz
-tar xf rethinkdb-{{site.version.major}}.{{site.version.minor}}.tgz
-cd rethinkdb-{{site.version.major}}.{{site.version.minor}}/
-```
-
-To build the latest development version of RethinkDB, follow the instructions below 
-for building with git.
-
-## Install build dependencies ##
+## Get the build dependencies ##
 
 There are a number of packages required for the build process. Most
-should be available for your operating system's repository. On Ubuntu,
-you can install build dependencies with apt-get:
+should be available for your operating system's repository. These packages are:
+
+- git
+- g++
+- protobuf
+- gperftools
+- libncurses5
+- boost
+- nodejs and npm
+
+
+On Ubuntu, you can install build dependencies with apt-get:
 
 ```bash
-sudo apt-get install g++ protobuf-compiler protobuf-c-compiler libprotobuf-dev libv8-dev libgoogle-perftools-dev make libprotoc-dev libboost-dev libtinfo-dev
+sudo apt-get install git-core g++ nodejs npm libprotobuf-dev libgoogle-perftools-dev \
+    libncurses5-dev libboost-all-dev nodejs-legacy
 ```
 
-## Build the server ##
-
-Configure and build RethinkDB:
-
-```bash
-./configure
-make
-```
-
-You'll find the `rethinkdb` binary in the `build/release/` subfolder.
-
-# Building with git #
-
-RethinkDB is being developed using git. You can clone the repository via git:
+## Get the source code ##
+Clone the RethinkDB repository:
 
 ```bash
 git clone --depth 1 -b v{{site.version.major}}.x https://github.com/rethinkdb/rethinkdb.git
 ```
 
-To get the latest working development branch, checkout `next` instead:
+## Build the server ##
+
+Kick off the build process:
 
 ```bash
-git clone --depth 1 https://github.com/rethinkdb/rethinkdb.git
-```
-
-Kick off the build: 
-
-```bash
+cd rethinkdb
 ./configure
 make
 ```
+
+You'll find the `rethinkdb` binary in the `build/release/` subfolder.

--- a/1-get-started/install/ubuntu.md
+++ b/1-get-started/install/ubuntu.md
@@ -31,6 +31,7 @@ If you do not have the `add-apt-repository` command, install it first:
 
 # Compile from source on Ubuntu 13.10 #
 
+## Get the build dependencies ##
 Install the main dependencies:
 
 ```


### PR DESCRIPTION
On 12.04, the default node version is (0.6) and we require a more recent one to install some dependencies.

The instructions were tested on 12.04 and 13.10.

I haven't tried 12.10 or 13.04, but it shouldn't be hard for users to figure out what to do.

@atnnn would you mind taking a look at it?
