### PR TITLE
Add timezone for r.time in python

### DIFF
--- a/api/python/index.md
+++ b/api/python/index.md
@@ -1823,7 +1823,7 @@ __Example:__ Retrieve all the posts that were posted between December 1st, 2013 
 
 ```py
 r.table("posts").filter(
-    r.row['date'].during(r.time(2013, 12, 1), r.time(2013, 12, 10))
+    r.row['date'].during(r.time(2013, 12, 1, "Z"), r.time(2013, 12, 10, "Z"))
 ).run(conn)
 ```
 


### PR DESCRIPTION
For `during` in index.md, we forgot to put the timezone in `r.time`.
The timezones are properly set in `api/python/dates-and-times/during.md`.

@atnnn could you take a look at that?
I'll take care of merging/deploying it.
