### PR TITLE
Add missing linebreak to 'data modeling in rethinkdb'

### DIFF
--- a/4-rethinkdb-in-practice/data-modeling-in-rethinkdb.md
+++ b/4-rethinkdb-in-practice/data-modeling-in-rethinkdb.md
@@ -78,7 +78,8 @@ data. A typical document in the `authors` table would look like this:
 ```json
 {
   "id": "7644aaf2-9928-4231-aa68-4e65e31bf219",
-  "name": "William Adama", "tv_show": "Battlestar Galactica"
+  "name": "William Adama",
+  "tv_show": "Battlestar Galactica"
 }
 ```
 


### PR DESCRIPTION
Perusing the docs and came across this small layout issue
