### PR TITLE
Michel 228 apisection

### DIFF
--- a/_scripts/dataexplorer.py
+++ b/_scripts/dataexplorer.py
@@ -19,6 +19,7 @@ def read_index(script_path, result):
     start_body_pattern = re.compile("{%\s*apibody\s*%}\s*")
     end_body_pattern = re.compile("{%\s*endapibody\s*%}\s*")
     ignore_pattern = re.compile("(.*Read more about this command.*)|(.*apisection.*)")
+    open_apisection = re.compile(".* apisection.*")
     example_pattern = re.compile("(__Example:__.*)|(__Example__:.*)")
 
     index_file = codecs.open(os.path.abspath(script_path+"/../api/javascript/index.md"), "r", "utf-8")
@@ -27,7 +28,13 @@ def read_index(script_path, result):
     current_description = ""
     parsing_body = False
     parsing_example = False
+    just_opened_api = False
+
     for line in index_file:
+        # If we just opened an api section, we are going to ignore everything until we hit a new method
+        if open_apisection.match(line) != None:
+            just_opened_api = True
+
         # Ignore the "read more about this command" lines
         if ignore_pattern.match(line) != None:
            continue 
@@ -51,7 +58,8 @@ def read_index(script_path, result):
             current_example = ""
             parsing_example = False
             parsing_body = False
-        else:
+            just_opened_api = False
+        elif just_opened_api == False:
             # Check if we hit a body tag
             if start_body_pattern.match(line) != None:
                 parsing_body = True


### PR DESCRIPTION
@atnnn -- can you take a quick look?

For `filter`, we used to have the description of the `Joins` api section. This commit fixes that.
I also tried the output with 1.12 in the data explorer, and everything seems to work.

Once you merged it, you can regenerate the `reql_docs.json` file, and push it to the rethinkdb repo.
And that should close https://github.com/rethinkdb/rethinkdb/issues/1982
