### PR TITLE
NoneType condition for run()

### DIFF
--- a/api/python/accessing-rql/run.md
+++ b/api/python/accessing-rql/run.md
@@ -18,7 +18,7 @@ query.run(conn, use_outdated=False, time_format='native', profile=False, durabil
 # Description #
 
 Run a query on a connection, returning either a single JSON result or
-a cursor, depending on the query.
+a cursor, depending on the query. If no documents match the query, it returns a NoneType object.
 
 The optional arguments are:
 


### PR DESCRIPTION
run() actually returns a NoneType object if no documents match the query. Should this be explicit in the API documentation since JSON or a cursor aren't the only return values for this function? 

Also, to be super nitpicky, when I'm running queries on Python 2.7 it's actually returning a Python 'dict' rather than a JSON object (I like this behavior, but it might be good to document it here rather than saying it's JSON). 

What do you think?
