### PR TITLE
Update index descriptions to match command docs

### DIFF
--- a/api/javascript/index.md
+++ b/api/javascript/index.md
@@ -1912,7 +1912,7 @@ not(bool) &rarr; bool
 
 Compute the logical inverse (not) of an expression.
 
-`not` can be called either postfix-style, immediately after an expression that evaluates as a boolean value, or infix-style, passing the expression as a parameter to `not`.
+`not` can be called either via method chaining, immediately after an expression that evaluates as a boolean value, or by passing the expression as a parameter to `not`.
 
 __Example:__ Not true is false.
 

--- a/api/python/index.md
+++ b/api/python/index.md
@@ -1857,7 +1857,7 @@ not_(bool) &rarr; bool
 
 Compute the logical inverse (not) of an expression.
 
-`not_` can be called either postfix-style, immediately after an expression that evaluates as a boolean value, or infix-style, passing the expression as a parameter to `not_`.
+`not_` can be called either via method chaining, immediately after an expression that evaluates as a boolean value, or by passing the expression as a parameter to `not_`.
 
 You may also use `~` as a shorthand operator.
 

--- a/api/ruby/index.md
+++ b/api/ruby/index.md
@@ -1822,7 +1822,7 @@ not(bool) &rarr; bool
 
 Compute the logical inverse (not) of an expression.
 
-`not` can be called either postfix-style, immediately after an expression that evaluates as a boolean value, or infix-style, passing the expression as a parameter to `not`.
+`not` can be called either via method chaining, immediately after an expression that evaluates as a boolean value, or by passing the expression as a parameter to `not`.
 
 __Example:__ Not true is false.
 


### PR DESCRIPTION
Noticed the older language was still in the index files, but only after the previous merge.
