### PR TITLE
Create a second file for Python 3 documentation.

### DIFF
--- a/_scripts/gen_python.py
+++ b/_scripts/gen_python.py
@@ -203,7 +203,7 @@ def add_doc(file_name, result_file, result_file3):
 
             result_file3.write("\n")
             result_file3.write(parent + name + ".__doc__" + " = ")
-            result_file3.write(repr(re.sub("(__Example:__)|(__Example__:)", "*Example:*", re.sub("^\n+", "", re.sub("\n{2,}", "\n\n", text)))))
+            result_file3.write("'''{}'''".format(re.sub("(__Example:__)|(__Example__:)", "*Example:*", re.sub("^\n+", "", re.sub("\n{2,}", "\n\n", text)))))
     else: # If the command has just one name and one parent
         if has_methods.get(parent, True):
             func = '.__func__'
@@ -216,7 +216,7 @@ def add_doc(file_name, result_file, result_file3):
 
         result_file3.write("\n")
         result_file3.write(parent + name + ".__doc__" + " = ")
-        result_file3.write(repr(re.sub("(__Example:__)|(__Example__:)", "*Example*", re.sub("^\n+", "", re.sub("\n{2,}", "\n\n", text)))))
+        result_file3.write("'''{}'''".format(re.sub("(__Example:__)|(__Example__:)", "*Example*", re.sub("^\n+", "", re.sub("\n{2,}", "\n\n", text)))))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In Python 3 the function doc string attribute is just `.__doc__`. In order to make the Python driver work with both versions I am proposing generating two files and using a `try: ... except ImportError: ...` to get the one that works at run time.
