### PR TITLE
Fix script for the data explorer docs

### DIFF
--- a/_scripts/dataexplorer.py
+++ b/_scripts/dataexplorer.py
@@ -116,7 +116,11 @@ def add_io_field(file_name, result):
                 yaml_raw += line
 
     yaml_data = yaml.load(yaml_raw)
-    result[yaml_data["permalink"]]["io"] = yaml_data["io"]
+    if "io" in yaml_data:
+        result[yaml_data["permalink"]]["io"] = yaml_data["io"]
+    else:
+        raise Exception("`io` field not found %s", file_name)
+
 
     details_file.close()
 

--- a/api/javascript/math-and-logic/random.md
+++ b/api/javascript/math-and-logic/random.md
@@ -5,6 +5,9 @@ permalink: api/javascript/random/
 command: random
 related_commands:
     'sample': sample/
+io:
+    - r
+    - number
 ---
 
 # Command syntax #


### PR DESCRIPTION
@AtnNn -- that provides a better error when the `io` field is missing in a command.

In this case, the `io` field for `r.random` was missing.
