### PR TITLE
Fix python docs (2)

### DIFF
--- a/_scripts/gen_python.py
+++ b/_scripts/gen_python.py
@@ -1,3 +1,6 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
 import re
 import markdown
 import os
@@ -198,7 +201,7 @@ def add_doc(file_name, result_file):
 
             result_file.write("\n")
             result_file.write(parent + name + func + ".__doc__" + " = ")
-            result_file.write(repr(re.sub("(__Example:__)|(__Example__:)", "*Example:*", re.sub("^\n+", "", re.sub("\n{2,}", "\n\n", text)))))
+            result_file.write(repr(re.sub("(__Example:__)|(__Example__:)", "*Example:*", re.sub("^\n+", "", re.sub("\n{2,}", "\n\n", text))).encode('utf-8')))
     else: # If the command has just one name and one parent
         if has_methods.get(parent, True):
             func = '.__func__'
@@ -207,7 +210,7 @@ def add_doc(file_name, result_file):
 
         result_file.write("\n")
         result_file.write(parent + name + func + ".__doc__" + " = ")
-        result_file.write(repr(re.sub("(__Example:__)|(__Example__:)", "*Example*", re.sub("^\n+", "", re.sub("\n{2,}", "\n\n", text)))))
+        result_file.write(repr(re.sub("(__Example:__)|(__Example__:)", "*Example*", re.sub("^\n+", "", re.sub("\n{2,}", "\n\n", text))).encode('utf-8')))
 
 
 if __name__ == "__main__":

--- a/api/javascript/control-structures/args.md
+++ b/api/javascript/control-structures/args.md
@@ -3,6 +3,9 @@ layout: api-command
 language: Javascript
 permalink: api/javascript/args/
 command: args
+io:
+    - r
+    - special
 ---
 
 # Command syntax #


### PR DESCRIPTION
That should fix #347 
- Add missing `io` field for `r.args`
- Fix encoding

The docs are just missing the `r.http` command, then everything should be ready to go.

Ping @AtnNn 
