### PR TITLE
Add python to the build dependencies

### DIFF
--- a/1-get-started/build.md
+++ b/1-get-started/build.md
@@ -20,9 +20,10 @@ should be available for your operating system's repository. These packages are:
 - g++
 - protobuf
 - gperftools
-- libncurses5
+- ncurses
 - boost
 - nodejs and npm
+- Python 2
 
 
 On Ubuntu 13.10+, you can install build dependencies with apt-get ([see instructions for previous versions](/docs/install/ubuntu/)):


### PR DESCRIPTION
Fixes #334 

Most distros have python 2 in the base isntall, and the arch linux instructions already included python 2.

Ping @neumino
