### PR TITLE
Make gen_python.py Python 3 compatible

### DIFF
--- a/_scripts/gen_python.py
+++ b/_scripts/gen_python.py
@@ -39,7 +39,7 @@ parents = {
 tags = {
     '[] (get_field)': [(query, '__getitem__')],
     '[] (nth)': [(query, 'nth')],
-    '[] (slice)': [(query, 'slice')],
+    'slice, []': [(query, 'slice')],
     '+': [(query, '__add__'), ('rethinkdb.', 'add')],
     '-': [(query, '__sub__'), ('rethinkdb.', 'sub')],
     '*': [(query, '__mul__'), ('rethinkdb.', 'mul')],


### PR DESCRIPTION
The `gen_python.py` script is modified to generate `docs.py` which can be used by both Python 2 and 3.

Currently, if the script is run by Python 3, the output is slightly different. Python 2 does not allow non-ascii characters to be printed in the `repr()` results, while Python 3 does not have such limitations.

This means that `docs.py` generated by Python 2 can be usable by Python 3, but the reverse is not true. As the current build system is served by Python 2, I think it would be OK to rely on this behavior.
