### PR TITLE
timeout option for r.connect

### DIFF
--- a/api/javascript/accessing-rql/connect.md
+++ b/api/javascript/accessing-rql/connect.md
@@ -32,7 +32,7 @@ options:
 - `port`: the port to connect on (default `28015`).
 - `db`: the default database (default `test`).
 - `authKey`: the authentication key (default none).
-- `timeout`: timeout period for the connection to be opened, by default `20` (seconds).
+- `timeout`: timeout period in seconds for the connection to be opened (default `20`).
 
 If the connection cannot be established, a `RqlDriverError` will be passed to the callback instead of a connection.
 

--- a/api/javascript/index.md
+++ b/api/javascript/index.md
@@ -40,7 +40,7 @@ Create a new connection to the database server.  Accepts the following options:
 - `port`: the port to connect on (default `28015`).
 - `db`: the default database (default `test`).
 - `authKey`: the authentication key (default none).
-- `timeout`: timeout period for the connection to be opened, by default `20` (seconds).
+- `timeout`: timeout period in seconds for the connection to be opened (default `20`).
 
 If the connection cannot be established, a `RqlDriverError` will be passed to the callback instead of a connection.
 

--- a/api/python/accessing-rql/connect.md
+++ b/api/python/accessing-rql/connect.md
@@ -26,7 +26,7 @@ Create a new connection to the database server. The keyword arguments are:
 - `port`: the driver port, by default `28015`.
 - `db`: the database used if not explicitly specified in a query, by default `test`.
 - `auth_key`: the authentification key, by default the empty string.
-- `timeout`: timeout period for the connection to be opened, by default `20` (seconds).
+- `timeout`: timeout period in seconds for the connection to be opened (default `20`).
 
 If the connection cannot be established, a `RqlDriverError` exception will be thrown.
 

--- a/api/python/index.md
+++ b/api/python/index.md
@@ -37,7 +37,7 @@ Create a new connection to the database server. The keyword arguments are:
 - `port`: the driver port, by default `28015`.
 - `db`: the database used if not explicitly specified in a query, by default `test`.
 - `auth_key`: the authentification key, by default the empty string.
-- `timeout`: timeout period for the connection to be opened, by default `20` (seconds).
+- `timeout`: timeout period in seconds for the connection to be opened (default `20`).
 
 If the connection cannot be established, a `RqlDriverError` exception will be thrown.
 


### PR DESCRIPTION
Second part of https://github.com/rethinkdb/docs/pull/353

The docs for ruby currently don't mention timeout since it's not yet implemented -- See https://github.com/rethinkdb/rethinkdb/issues/1666
I used the same description as in the Python docs.

@chipotle -- could you review this for me?
