### PR TITLE
Quiet wget in the ubuntu installation instructions

### DIFF
--- a/1-get-started/install/debian.md
+++ b/1-get-started/install/debian.md
@@ -19,7 +19,7 @@ your list of repositories and then install via `apt-get`:
 
 ```bash
 echo "deb http://download.rethinkdb.com/apt lucid main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
-wget -O- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
+wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install rethinkdb
 ```

--- a/1-get-started/install/mint.md
+++ b/1-get-started/install/mint.md
@@ -16,7 +16,7 @@ repositories and then install via `apt-get`:
 
 ```bash
 echo "deb http://download.rethinkdb.com/apt saucy main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
-wget -O- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
+wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install rethinkdb
 ```

--- a/1-get-started/install/ubuntu.md
+++ b/1-get-started/install/ubuntu.md
@@ -19,7 +19,7 @@ following lines into your terminal:
 
 ```bash
 source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
-wget -O- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
+wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install rethinkdb
 ```


### PR DESCRIPTION
The non-important output of `wget` hides the important output of `sudo` and `apt-key`

@neumino Could you please review, merge and push this?
