### PR TITLE
Fix instructions for Arch

### DIFF
--- a/1-get-started/install/arch.md
+++ b/1-get-started/install/arch.md
@@ -62,7 +62,7 @@ Kick off the build process:
 
 ```bash
 cd rethinkdb
-./configure --dynamic tcmalloc_minimal 
+./configure --dynamic tcmalloc_minimal --allow-fetch --fetch v8
 make
 ```
 


### PR DESCRIPTION
We need `allow-fetch` for less/coffeescript/etc and `--fetch v8` for https://github.com/rethinkdb/rethinkdb/issues/2421

@AtnNn -- could you take a look?
