### PR TITLE
Update pip install command

### DIFF
--- a/3-cluster-administration/migration.md
+++ b/3-cluster-administration/migration.md
@@ -45,7 +45,7 @@ your data.
 
 __Note:__ The `dump` command requires the [Python driver](/docs/install-drivers/python/) to be installed. Don't upgrade the Python driver until after you've dumped the data!
 
-If you don't have the Python driver installed, you can install the previous version using `pip install rethinkdb version==1.12.0-2`. (You can use the [Python Package Index](https://pypi.python.org/pypi "PyPI") to check on current and older versions.)
+If you don't have the Python driver installed, you can install the previous version using `pip install rethinkdb==1.12.0-2`. (You can use the [Python Package Index](https://pypi.python.org/pypi "PyPI") to check on current and older versions.)
 {% endinfobox %}
 
 {% infobox info %}


### PR DESCRIPTION
The old command failed to install the dependency. Running the command returned error:

```
Downloading/unpacking version==1.12.0-2
Could not find a version that satisfies the requirement version==1.12.0-2 (from versions: 0.1.0, 0.1.1)
Cleaning up...
No distributions matching the version for version==1.12.0-2
```

When asked about the issue via IRC @atnnn told me that the error is not OS dependent, so therefore I deiced to file a pull request for it.
