### PR TITLE
Replace tabs with spaces

### DIFF
--- a/api/javascript/control-structures/coerce_to.md
+++ b/api/javascript/control-structures/coerce_to.md
@@ -13,7 +13,7 @@ io:
     -   - object
         - array
     -   - binary
-    	- string
+        - string
     -   - string
         - binary
 related_commands:

--- a/api/javascript/transformations/slice.md
+++ b/api/javascript/transformations/slice.md
@@ -9,7 +9,7 @@ io:
     -   - array
         - array
     -   - binary
-    	- binary
+        - binary
 related_commands:
     order_by: order_by/
     skip: skip/


### PR DESCRIPTION
Jekyll keeps complaining with 1.14 with errors like:

```
Regenerating: 2 files at 2014-08-12 16:27:15 Error reading file /home/michel/projects/rethinkdb-all/rethinkdb-www/docs/api/javascript/transformations/slice.md: (<unknown>): found a tab character that violate intendation while scanning a plain scalar at line 11 column 11
```

There were two tabs in the yaml format, I just replaced them with spaces.

@chipotle -- can you take a look at this?
