### PR TITLE
Missing `feed` usage in `cursor.each` {%  apibody %}

### DIFF
--- a/api/javascript/cursors/each.md
+++ b/api/javascript/cursors/each.md
@@ -19,6 +19,7 @@ related_commands:
 {% apibody %}
 cursor.each(callback[, onFinishedCallback])
 array.each(callback[, onFinishedCallback])
+feed.each(callback)
 {% endapibody %}
 
 # Description #


### PR DESCRIPTION
Hey, don't see which branch to send PRs to, so sending to master.
