### PR TITLE
Typo fix in Ruby insert docs

### DIFF
--- a/api/ruby/writing-data/insert.md
+++ b/api/ruby/writing-data/insert.md
@@ -12,7 +12,7 @@ related_commands:
 # Command syntax #
 
 {% apibody %}
-table.insert(json | [json][, :durability => "hard", :return_changes => false :conflict => "error"])
+table.insert(json | [json][, :durability => "hard", :return_changes => false, :conflict => "error"])
     &rarr; object
 {% endapibody %}
 


### PR DESCRIPTION
The Ruby documentation for `insert` is missing a comma after the `return_changes` option.
