### PR TITLE
Reorganize/clarify cluster documentation

### DIFF
--- a/5-deploying-rethinkdb/cluster-on-startup.md
+++ b/5-deploying-rethinkdb/cluster-on-startup.md
@@ -7,6 +7,81 @@ permalink: docs/cluster-on-startup/
 alias: docs/guides/startup/
 ---
 
+This document explains configuration options and offers tips on various ways to start one or more RethinkDB instances on startup, depending on the operating system and distribution. For general instructions on starting RethinkDB, see "[Start a RethinkDB cluster][src]."
+
+[src]: /docs/start-a-cluster/
+
+To configure a multi-node RethinkDB cluster to run on startup, start separate instances with their own configuration files, including the `join` configuration option for each node with the IP address and port of another node in the cluster. If the instances are not running on the same machine, also specify `bind=all` in the configuration file (or `--bind all` on the command line).
+
+# Configuration options #
+
+The `.conf` file includes a number of options exclusively for the
+init script. The rest of the options are exactly the same as the ones
+that go on the command line to the RethinkDB server. For more details
+about these options run `rethinkdb help`.
+
+The configuration file's location depends on the startup system your distribution uses. For `init.d` and `systemd`, follow the directions below. A configuration file may also be specified on the command line with the `--config-file` option.
+
+## Supported options ##
+
+For some of the options below, the default value depends on `<name>`, the name of the
+config file without the `.conf` extension.
+
+* `runuser` and `rungroup` &mdash; specifies which
+  user and group should be used launch the Rethinkdb process.   
+  *Default*: `rethinkdb` and `rethinkdb`.
+
+* `pid-file` &mdash; the location of the file with the RethinkDB instance process ID (used by the init script to communicate with
+  the server process).   
+  *Default*: `/var/run/rethinkdb/<name>/pid_file` 
+
+* `directory` &mdash; the data directory where
+  database tables will be stored. This location must be readable and
+  writable by the user or group (or both) specified by `runuser`
+  and `rungroup`.   
+  _Note_: It is best to create the database manually via
+  `rethinkdb create --directory ...` as `runuser` or `rungroup` before
+  enabling auto-start.  
+  *Default*: `/var/lib/rethinkdb/<name>/`
+
+* `log-file` &mdash; path to the log file.  
+  *Default*: `<directory>/log_file`
+
+* `bind` &mdash; Address of local interfaces to listen on when accepting connections.
+   May be 'all' or an IP address, loopback addresses are enabled by default.  
+   *Default*: all local addresses
+
+* `canonical-address` &mdash; Address that other rethinkdb instances will use to connect to this machine.
+  It can be specified multiple times.
+
+* `http-port`, `driver-port`, and `cluster-port` &mdash; the web UI
+  port (default `8080`), the client driver port (default
+  `28015`), and intracluster traffic port (default `29015`),
+  respectively.
+
+* `join` &mdash; The `host:port` of a node that Rethinkdb will connect to.
+  It can be specified multiple times.
+
+* `port-offset` All ports used locally will have this value added.  
+  *Default*: 0
+  
+* `no-http-admin` &mdash; Disable web administration console.
+
+* `cores` &mdash; Number of cores to use.  
+  *Default*: Number of cores of the CPU.
+
+* `cache-size` &mdash; Size of the cache in MB.  
+  *Default*: Half of the available RAM on startup.
+
+* `io-threads` &mdash; Number of simultaneous I/O operations can happen at the same time.  
+  *Default*: 64
+
+* `no-direct-io` &mdash; Disable direct I/O.
+
+* `machine-name` &mdash; The name for this machine (as it will appear in the metadata).  
+  *Default*: Randomly chosen from a short list of names.
+
+
 # Startup with init.d #
 
 On Linux, RethinkDB packages automatically install an init script at
@@ -98,74 +173,6 @@ __You've now got a working server!__
 
 Since `systemd` supports multiple instances, starting a new instance
 of RethinkDB only requires creating another `.conf` file.
-
-# Configuration options #
-
-The `.conf` file includes a number of options exclusively for the
-init script. The rest of the options are exactly the same as the ones
-that go on the command line to the RethinkDB server. For more details
-about these options run `rethinkdb help`.
-
-## Supported options ##
-
-For some of the options below, the default value depends on `<name>`, the name of the
-config file without the `.conf` extension.
-
-* `runuser` and `rungroup` &mdash; specifies which
-  user and group should be used launch the Rethinkdb process.   
-  *Default*: `rethinkdb` and `rethinkdb`.
-
-* `pid-file` &mdash; the location of the file with the RethinkDB instance process ID (used by the init script to communicate with
-  the server process).   
-  *Default*: `/var/run/rethinkdb/<name>/pid_file` 
-
-* `directory` &mdash; the data directory where
-  database tables will be stored. This location must be readable and
-  writable by the user or group (or both) specified by `runuser`
-  and `rungroup`.   
-  _Note_: It is best to create the database manually via
-  `rethinkdb create --directory ...` as `runuser` or `rungroup` before
-  enabling auto-start.  
-  *Default*: `/var/lib/rethinkdb/<name>/`
-
-* `log-file` &mdash; path to the log file.  
-  *Default*: `<directory>/log_file`
-
-* `bind` &mdash; Address of local interfaces to listen on when accepting connections.
-   May be 'all' or an IP address, loopback addresses are enabled by default.  
-   *Default*: all local addresses
-
-* `canonical-address` &mdash; Address that other rethinkdb instances will use to connect to this machine.
-  It can be specified multiple times.
-
-* `http-port`, `driver-port`, and `cluster-port` &mdash; the web UI
-  port (default `8080`), the client driver port (default
-  `28015`), and intracluster traffic port (default `29015`),
-  respectively.
-
-* `join` &mdash; The `host:port` of a node that Rethinkdb will connect to.
-  It can be specified multiple times.
-
-* `port-offset` All ports used locally will have this value added.  
-  *Default*: 0
-  
-* `no-http-admin` &mdash; Disable web administration console.
-
-* `cores` &mdash; Number of cores to use.  
-  *Default*: Number of cores of the CPU.
-
-* `cache-size` &mdash; Size of the cache in MB.  
-  *Default*: Half of the available RAM on startup.
-
-* `io-threads` &mdash; Number of simultaneous I/O operations can happen at the same time.  
-  *Default*: 64
-
-* `no-direct-io` &mdash; Disable direct I/O.
-
-* `machine-name` &mdash; The name for this machine (as it will appear in the metadata).  
-  *Default*: Randomly chosen from a short list of names.
-
-
 
 # Troubleshooting #
 


### PR DESCRIPTION
@mglukhovsky - this adds a little preface and moves the configuration file description to the top of the document rather than the end; I think it's probably better to talk about configuration options first, because they're applicable whether you're using `init.d` or `systemd`. (We also should probably add something for OS X, but that's another ticket, and I don't know what defaults we actually expect under that...)
