### PR TITLE
Use rethinkdb-latest instead of version-qualified link

### DIFF
--- a/1-get-started/install/osx.md
+++ b/1-get-started/install/osx.md
@@ -12,7 +12,7 @@ permalink: docs/install/osx/
 
 _Prerequisites:_ We provide native binaries for OS X Lion and above (>= 10.7).
 
-[Download](http://download.rethinkdb.com/osx/rethinkdb-{{site.version.major}}.{{site.version.minor}}.dmg) the disk
+[Download](http://download.rethinkdb.com/osx/rethinkdb-latest.dmg) the disk
 image, run `rethinkdb.pkg`, and follow the installation instructions.
 
 # Using Homebrew #


### PR DESCRIPTION
The package for this release is named `rethinkdb-1.15.3-1.dmg` instead of `rethinkdb-1.15.3.dmg`. `rethinkdb-latest.dmg` always points to the latest release.