### PR TITLE
Fix typo in polygon command description

### DIFF
--- a/2-query-language/geo-support/javascript.md
+++ b/2-query-language/geo-support/javascript.md
@@ -151,7 +151,7 @@ Only longitude/latitude coordinates are supported. GeoJSON objects that use Cart
 * [toGeojson](to_geojson/)/[to_geojson](/api/javascript/to_geojson/): convert a geometry object to a GeJSON object
 * [point](/api/javascript/point/): create a point object
 * [line](/api/javascript/line/): create a line object
-* [polygon](/api/javascript/polygon/): create a line object
+* [polygon](/api/javascript/polygon/): create a polygon object
 * [circle](/api/javascript/circle/): create a line or polygon that approximates a circle
 * [distance](/api/javascript/distance/): compute the distance between a point and another geometry object
 * [intersects](/api/javascript/intersects/): determine whether two geometry objects intersect

--- a/2-query-language/geo-support/python.md
+++ b/2-query-language/geo-support/python.md
@@ -149,7 +149,7 @@ Only longitude/latitude coordinates are supported. GeoJSON objects that use Cart
 * [to_geojson](to_geojson/)/[to_geojson](/api/python/to_geojson/): convert a geometry object to a GeJSON object
 * [point](/api/python/point/): create a point object
 * [line](/api/python/line/): create a line object
-* [polygon](/api/python/polygon/): create a line object
+* [polygon](/api/python/polygon/): create a polygon object
 * [circle](/api/python/circle/): create a line or polygon that approximates a circle
 * [distance](/api/python/distance/): compute the distance between a point and another geometry object
 * [intersects](/api/python/intersects/): determine whether two geometry objects intersect

--- a/2-query-language/geo-support/ruby.md
+++ b/2-query-language/geo-support/ruby.md
@@ -149,7 +149,7 @@ Only longitude/latitude coordinates are supported. GeoJSON objects that use Cart
 * [to_geojson](to_geojson/)/[to_geojson](/api/ruby/to_geojson/): convert a geometry object to a GeJSON object
 * [point](/api/ruby/point/): create a point object
 * [line](/api/ruby/line/): create a line object
-* [polygon](/api/ruby/polygon/): create a line object
+* [polygon](/api/ruby/polygon/): create a polygon object
 * [circle](/api/ruby/circle/): create a line or polygon that approximates a circle
 * [distance](/api/ruby/distance/): compute the distance between a point and another geometry object
 * [intersects](/api/ruby/intersects/): determine whether two geometry objects intersect


### PR DESCRIPTION
"create a line object" -> "create a polygon object"