### PR TITLE
Fix unclosed code fence

### DIFF
--- a/4-rethinkdb-in-practice/cookbook/python.md
+++ b/4-rethinkdb-in-practice/cookbook/python.md
@@ -742,6 +742,7 @@ But you'd like to get a document more like a "report card":
     "Mathematics": 70,
     "English": 90
 }
+```
 
 You can accomplish this with `object` and a pivot.
 


### PR DESCRIPTION
The final example in the [dynamic keys section of the Python cookbook](http://rethinkdb.com/docs/cookbook/python/#using-dynamic-keys-in-reql-commands) contained an unclosed code fence.

Before:

![rethinkdb_docs_before](https://cloud.githubusercontent.com/assets/1709537/7789406/0d1c0cfa-022d-11e5-8a96-a5db8cf72cec.PNG)

After:

![rethinkdb_docs_after](https://cloud.githubusercontent.com/assets/1709537/7789407/10fcea7e-022d-11e5-9ca9-cd024c43921d.png)

It's a small fix, but I hope it helps!