### PR TITLE
Changing URL to match that of URL provided in the list of example projects. 

### DIFF
--- a/1-get-started/guide/python.md
+++ b/1-get-started/guide/python.md
@@ -52,8 +52,7 @@ The `repl` command is a convenience method that sets a default connection in you
 {% infobox %}
 __Note:__ the `repl` command is useful to experiment in the shell, but
 you should pass the connection to the `run` command explicitly in
-real applications. See [an example
-project](/docs/examples/flask-backbone-todo/) for more details.
+real applications. See [an example project](//github.com/rethinkdb/rethinkdb-example-flask-backbone-todo) for more details.
 {% endinfobox%}
 
 # Create a new table #


### PR DESCRIPTION
Changing URL to match that of URL provided in the list of example projects :snake: Python projects. Also, the old URL was pointing to a page that wasn't using the new CSS properly [viewable here and is live](http://rethinkdb.com/docs/examples/flask-backbone-todo/).