### PR TITLE
Updating to supported RethinkDB Adapter

### DIFF
--- a/1-get-started/drivers/index.md
+++ b/1-get-started/drivers/index.md
@@ -139,7 +139,7 @@ alias: docs/guides/drivers/
                 </a>
             </li>
             <li>
-            <a href="https://github.com/azukiapp/elixir-rethinkdb">
+            <a href="https://github.com/hamiltop/rethinkdb-elixir">
                 <img src="/assets/images/docs/driver-languages/elixir.png" />
                 <p class="name">Elixir</p>
             </a>


### PR DESCRIPTION
The current rethinkdb driver listed on the website is unsupported. The one linked is supported and up to date.