### PR TITLE
Fix syntax error missing quote around string

### DIFF
--- a/api/javascript/geospatial/to_geojson.md
+++ b/api/javascript/geospatial/to_geojson.md
@@ -24,7 +24,7 @@ Convert a ReQL geometry object to a [GeoJSON][] object.
 __Example:__ Convert a ReQL geometry object to a GeoJSON object.
 
 ```js
-r.table(geo).get('sfo')('location').toGeojson().run(conn, callback);
+r.table('geo').get('sfo')('location').toGeojson().run(conn, callback);
 // result passed to callback
 {
     'type': 'Point',

--- a/api/javascript/index.md
+++ b/api/javascript/index.md
@@ -2760,7 +2760,7 @@ Convert a ReQL geometry object to a [GeoJSON][] object.
 __Example:__ Convert a ReQL geometry object to a GeoJSON object.
 
 ```js
-r.table(geo).get('sfo')('location').toGeojson.run(conn, callback);
+r.table('geo').get('sfo')('location').toGeojson.run(conn, callback);
 // result passed to callback
 {
     'type': 'Point',

--- a/api/python/geospatial/to_geojson.md
+++ b/api/python/geospatial/to_geojson.md
@@ -21,7 +21,7 @@ Convert a ReQL geometry object to a [GeoJSON][] object.
 __Example:__ Convert a ReQL geometry object to a GeoJSON object.
 
 ```py
-> r.table(geo).get('sfo')['location'].to_geojson().run(conn)
+> r.table('geo').get('sfo')['location'].to_geojson().run(conn)
 
 {
     'type': 'Point',

--- a/api/python/index.md
+++ b/api/python/index.md
@@ -2752,7 +2752,7 @@ Convert a ReQL geometry object to a [GeoJSON][] object.
 __Example:__ Convert a ReQL geometry object to a GeoJSON object.
 
 ```py
-> r.table(geo).get('sfo')['location'].to_geojson.run(conn)
+> r.table('geo').get('sfo')['location'].to_geojson.run(conn)
 
 {
     'type': 'Point',

--- a/api/ruby/geospatial/to_geojson.md
+++ b/api/ruby/geospatial/to_geojson.md
@@ -21,7 +21,7 @@ Convert a ReQL geometry object to a [GeoJSON][] object.
 __Example:__ Convert a ReQL geometry object to a GeoJSON object.
 
 ```rb
-> r.table(geo).get('sfo')['location'].to_geojson.run(conn)
+> r.table('geo').get('sfo')['location'].to_geojson.run(conn)
 
 {
     :type => 'Point',

--- a/api/ruby/index.md
+++ b/api/ruby/index.md
@@ -2720,7 +2720,7 @@ Convert a ReQL geometry object to a [GeoJSON][] object.
 __Example:__ Convert a ReQL geometry object to a GeoJSON object.
 
 ```rb
-> r.table(geo).get('sfo')['location'].to_geojson.run(conn)
+> r.table('geo').get('sfo')['location'].to_geojson.run(conn)
 
 {
     :type => 'Point',


### PR DESCRIPTION
`table(geo)` should be `table('geo')`