### PR TITLE
Don't run change feeds on separate connection

### DIFF
--- a/api/javascript/manipulating-tables/changes.md
+++ b/api/javascript/manipulating-tables/changes.md
@@ -61,8 +61,6 @@ The server will buffer up to 100,000 elements. If the buffer limit is hit, early
 
 Commands that operate on streams (such as [filter](/api/javascript/filter/) or [map](/api/javascript/map/)) can usually be chained after `changes`.  However, since the stream produced by `changes` has no ending, commands that need to consume the entire stream before returning (such as [reduce](/api/javascript/reduce/) or [count](/api/javascript/count/)) cannot.
 
-It's a good idea to open changefeeds on their own connection. If you don't, other queries run on the same connection will experience unpredictable latency spikes while the connection blocks on more changes.
-
 __Example:__ Subscribe to the changes on a table.
 
 Start monitoring the changefeed in one client:


### PR DESCRIPTION
I'm not 100% sure if this is right or not, opening a PR for discussion. With the protocol changes in v0_4, I don't think we need to run change feeds on separate connections.

If that's correct I can update the other platform docs too.