### PR TITLE
Fixed inconsistency in table_create api docs

### DIFF
--- a/api/javascript/manipulating-tables/table_create.md
+++ b/api/javascript/manipulating-tables/table_create.md
@@ -30,7 +30,7 @@ If successful, the command returns an object with two fields:
     * `old_val`: always `null`.
     * `new_val`: the table's new [config](/api/javascript/config) value.
 
-If a table with the same name already exists, the command throws `ReqlRuntimeError`.
+If a table with the same name already exists, the command throws `ReqlOpFailedError`.
 
 Note: Only alphanumeric characters and underscores are valid for the table name.
 

--- a/api/python/manipulating-tables/table_create.md
+++ b/api/python/manipulating-tables/table_create.md
@@ -27,7 +27,7 @@ If successful, the command returns an object with two fields:
     * `old_val`: always `None`.
     * `new_val`: the table's new [config](/api/python/config) value.
 
-If a table with the same name already exists, the command throws `ReqlRuntimeError`.
+If a table with the same name already exists, the command throws `ReqlOpFailedError`.
 
 Note: Only alphanumeric characters and underscores are valid for the table name.
 

--- a/api/ruby/manipulating-tables/table_create.md
+++ b/api/ruby/manipulating-tables/table_create.md
@@ -27,7 +27,7 @@ If successful, the command returns an object with two fields:
     * `old_val`: always `nil`.
     * `new_val`: the table's new [config](/api/ruby/config) value.
 
-If a table with the same name already exists, the command throws `ReqlRuntimeError`.
+If a table with the same name already exists, the command throws `ReqlOpFailedError`.
 
 Note: Only alphanumeric characters and underscores are valid for the table name.
 


### PR DESCRIPTION
All three versions of the API docs state that trying to create a table
with a name that duplicates an existing table will raise a
ReqlRuntimeError. This contradicts the test at lines 132-136 of
test/rql_test/src/meta/table.yaml which specifies that in this case a
ReqlOpFailedError should be raised.

Docs have been updated to match behavior specified by test.