### PR TITLE
Add m4 to dependency install list

### DIFF
--- a/_jekyll/_includes/debian-based-install-from-source.md
+++ b/_jekyll/_includes/debian-based-install-from-source.md
@@ -8,7 +8,7 @@ Install the dependencies:
 sudo apt-get install build-essential protobuf-compiler python \
                      libprotobuf-dev libcurl4-openssl-dev \
                      libboost-all-dev libncurses5-dev \
-                     libjemalloc-dev wget
+                     libjemalloc-dev wget m4
 ```
 
 ## Get the source code ##


### PR DESCRIPTION
m4 wasn't in my clean install of Ubuntu 15 server, causing `sudo make install` to fail.  `sudo apt-get install m4` fixed, the problem, so I assume nothing else is pulling it in and bringing it in with the other build dependencies will fix the problem.