### PR TITLE
Fix missing close ``` for code block

### DIFF
--- a/api/ruby/aggregation/max.md
+++ b/api/ruby/aggregation/max.md
@@ -42,6 +42,7 @@ __Example:__ Return the user who has scored the most points.
 
 ```rb
 r.table('users').max('points').run(conn)
+```
 
 __Example:__ The same as above, but using a secondary index on the `points` field.
 


### PR DESCRIPTION
The ruby doc for max forgot closing code block with ```

<img width="823" alt="screen shot 2015-08-25 at 11 25 57 pm" src="https://cloud.githubusercontent.com/assets/49754/9486808/d26feeee-4b80-11e5-9033-1bd04b76cf33.png">
