### PR TITLE
Changed some download links to https

### DIFF
--- a/0-getting-started/build.md
+++ b/0-getting-started/build.md
@@ -34,7 +34,7 @@ The `./configure` script can install some of these dependencies if they are miss
 Download and extract the archive:
 
 ```bash
-wget http://download.rethinkdb.com/dist/rethinkdb-{{site.version.full}}.tgz
+wget https://download.rethinkdb.com/dist/rethinkdb-{{site.version.full}}.tgz
 tar xf rethinkdb-{{site.version.full}}.tgz
 ```
 

--- a/0-getting-started/install/arch.md
+++ b/0-getting-started/install/arch.md
@@ -82,7 +82,7 @@ You will need to install the `base-devel` group and several additional build dep
 Download and extract the archive:
 
 ```bash
-$ wget http://download.rethinkdb.com/dist/rethinkdb-{{site.version.full}}.tgz
+$ wget https://download.rethinkdb.com/dist/rethinkdb-{{site.version.full}}.tgz
 $ tar xf rethinkdb-{{site.version.full}}.tgz
 ```
 

--- a/0-getting-started/install/centos.md
+++ b/0-getting-started/install/centos.md
@@ -14,7 +14,7 @@ We provide binaries for both 32-bit and 64-bit CentOS 6.
 To install the server, add the [RethinkDB yum repository](http://download.rethinkdb.com/centos) to your list of repositories and install:
 
 ```bash
-sudo wget http://download.rethinkdb.com/centos/6/`uname -m`/rethinkdb.repo \
+sudo wget https://download.rethinkdb.com/centos/6/`uname -m`/rethinkdb.repo \
           -O /etc/yum.repos.d/rethinkdb.repo
 sudo yum install rethinkdb
 ```
@@ -46,7 +46,7 @@ package. Installing these dependencies from the EPEL repositories will
 allow RethinkDB to build more quickly:
 
 ```bash
-sudo rpm -Uvh http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+sudo rpm -Uvh https://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 sudo yum install protobuf-devel jemalloc-devel
 ```
 
@@ -55,7 +55,7 @@ sudo yum install protobuf-devel jemalloc-devel
 Download and extract the source tarball:
 
 ```bash
-wget http://download.rethinkdb.com/dist/rethinkdb-{{site.version.full}}.tgz
+wget https://download.rethinkdb.com/dist/rethinkdb-{{site.version.full}}.tgz
 tar xf rethinkdb-{{site.version.full}}.tgz
 ```
 

--- a/0-getting-started/install/centos.md
+++ b/0-getting-started/install/centos.md
@@ -46,7 +46,7 @@ package. Installing these dependencies from the EPEL repositories will
 allow RethinkDB to build more quickly:
 
 ```bash
-sudo rpm -Uvh https://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+sudo rpm -Uvh http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 sudo yum install protobuf-devel jemalloc-devel
 ```
 

--- a/0-getting-started/install/debian.md
+++ b/0-getting-started/install/debian.md
@@ -19,7 +19,7 @@ following lines into your terminal:
 
 ```bash
 echo "deb http://download.rethinkdb.com/apt `lsb_release -cs` main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
-wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
+wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install rethinkdb
 ```

--- a/0-getting-started/install/fedora.md
+++ b/0-getting-started/install/fedora.md
@@ -16,7 +16,7 @@ Fedora.
 To install the server, add the RethinkDB yum repository to your list of repositories and install:
 
 ```bash
-sudo wget http://download.rethinkdb.com/centos/6/`uname -m`/rethinkdb.repo \
+sudo wget https://download.rethinkdb.com/centos/6/`uname -m`/rethinkdb.repo \
     -O /etc/yum.repos.d/rethinkdb.repo
 sudo yum install rethinkdb
 ```
@@ -41,7 +41,7 @@ sudo yum install gcc-c++ protobuf-devel ncurses-devel jemalloc-devel \
 Download and extract the source tarball:
 
 ```bash
-wget http://download.rethinkdb.com/dist/rethinkdb-{{site.version.full}}.tgz
+wget https://download.rethinkdb.com/dist/rethinkdb-{{site.version.full}}.tgz
 tar xf rethinkdb-{{site.version.full}}.tgz
 ```
 

--- a/0-getting-started/install/index.md
+++ b/0-getting-started/install/index.md
@@ -121,4 +121,4 @@ more platforms.
 
 # Older versions #
 
-Binaries for previous versions of RethinkDB are available in the [download archive](http://download.rethinkdb.com).
+Binaries for previous versions of RethinkDB are available in the [download archive](https://download.rethinkdb.com).

--- a/0-getting-started/install/mint.md
+++ b/0-getting-started/install/mint.md
@@ -25,7 +25,7 @@ echo "deb http://download.rethinkdb.com/apt trusty main" | sudo tee /etc/apt/sou
 
 ## Install RethinkDB ##
 ```bash
-wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
+wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install rethinkdb
 ```

--- a/0-getting-started/install/opensuse.md
+++ b/0-getting-started/install/opensuse.md
@@ -27,7 +27,7 @@ sudo zypper in make gcc gcc-c++ protobuf-devel ncurses-devel \
 Download and extract the archive:
 
 ```bash
-wget http://download.rethinkdb.com/dist/rethinkdb-{{site.version.full}}.tgz
+wget https://download.rethinkdb.com/dist/rethinkdb-{{site.version.full}}.tgz
 tar xf rethinkdb-{{site.version.full}}.tgz
 ```
 

--- a/0-getting-started/install/osx.md
+++ b/0-getting-started/install/osx.md
@@ -11,7 +11,7 @@ permalink: docs/install/osx/
 
 _Prerequisites:_ We provide native binaries for OS X Lion and above (>= 10.7).
 
-[Download](http://download.rethinkdb.com/osx/rethinkdb-{{site.version.full}}.dmg) the disk
+[Download](https://download.rethinkdb.com/osx/rethinkdb-{{site.version.full}}.dmg) the disk
 image, run `rethinkdb.pkg`, and follow the installation instructions.
 
 # Using Homebrew #
@@ -37,7 +37,7 @@ build from source.
 Download and extract the archive:
 
 ```bash
-wget http://download.rethinkdb.com/dist/rethinkdb-{{site.version.full}}.tgz
+wget https://download.rethinkdb.com/dist/rethinkdb-{{site.version.full}}.tgz
 tar xf rethinkdb-{{site.version.full}}.tgz
 ```
 

--- a/0-getting-started/install/raspbian.md
+++ b/0-getting-started/install/raspbian.md
@@ -34,7 +34,7 @@ Make also sure that you have at least 1GB available on your SD card.
 Download and extract the archive:
 
 ```bash
-wget http://download.rethinkdb.com/dist/rethinkdb-{{site.version.full}}.tgz
+wget https://download.rethinkdb.com/dist/rethinkdb-{{site.version.full}}.tgz
 tar xf rethinkdb-{{site.version.full}}.tgz
 ```
 

--- a/0-getting-started/install/ubuntu.md
+++ b/0-getting-started/install/ubuntu.md
@@ -19,7 +19,7 @@ following lines into your terminal:
 
 ```bash
 source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
-wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
+wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install rethinkdb
 ```

--- a/_jekyll/_includes/debian-based-install-from-source.md
+++ b/_jekyll/_includes/debian-based-install-from-source.md
@@ -16,7 +16,7 @@ sudo apt-get install build-essential protobuf-compiler python \
 Download and extract the archive:
 
 ```bash
-wget http://download.rethinkdb.com/dist/rethinkdb-{{site.version.full}}.tgz
+wget https://download.rethinkdb.com/dist/rethinkdb-{{site.version.full}}.tgz
 tar xf rethinkdb-{{site.version.full}}.tgz
 ```
 


### PR DESCRIPTION
download.rethinkdb.com now supports https. I switched some of the links over (most importantly the ones where we download a gpg key for the debian/ubuntu packages).