### PR TITLE
ALLOW_WARNINGS=1 for Raspbian build instructions

### DIFF
--- a/0-getting-started/install/raspbian.md
+++ b/0-getting-started/install/raspbian.md
@@ -45,8 +45,8 @@ Kick off the build process:
 ```bash
 cd rethinkdb-{{site.version.full}}
 ./configure --with-system-malloc --allow-fetch
-make
-sudo make install
+make ALLOW_WARNINGS=1
+sudo make install ALLOW_WARNINGS=1
 ```
 
 {% include docs/install-next-step.md %}


### PR DESCRIPTION
As suggested by @mogren https://github.com/rethinkdb/rethinkdb/issues/4541#issuecomment-138243806