### PR TITLE
Clarity in data modeling documentation

### DIFF
--- a/2-data-model/data-modeling-in-rethinkdb.md
+++ b/2-data-model/data-modeling-in-rethinkdb.md
@@ -65,7 +65,7 @@ __Advantages of using embedded arrays:__
 
 __Disadvantages of using embedded arrays:__
 
-- Any operation on a document in the `author` table requires loading all posts into memory. As well, any update to the document requires rewriting the entire document to disk. At the moment, RethinkDB does not support modifying only the single value on disk. 
+- Any operation on a document in the `author` table requires loading all posts into memory. Note, any update to the document requires rewriting the entire document to disk. 
 - Because of the previous limitation, it's best to keep the size of
   the `posts` array to no more than a few hundred documents.
 

--- a/2-data-model/data-modeling-in-rethinkdb.md
+++ b/2-data-model/data-modeling-in-rethinkdb.md
@@ -65,7 +65,7 @@ __Advantages of using embedded arrays:__
 
 __Disadvantages of using embedded arrays:__
 
-- Any operation on a document in the `author` table requires loading all posts into memory. Note that any update to a document requires rewriting the entire document to disk. 
+- Deleting, adding or updating a post requires loading the entire `posts` array, modifying it, and writing the entire document back to disk.
 - Because of the previous limitation, it's best to keep the size of
   the `posts` array to no more than a few hundred documents.
 

--- a/2-data-model/data-modeling-in-rethinkdb.md
+++ b/2-data-model/data-modeling-in-rethinkdb.md
@@ -65,7 +65,7 @@ __Advantages of using embedded arrays:__
 
 __Disadvantages of using embedded arrays:__
 
-- Any operation on a document in the `author` table requires loading all posts into memory. Note, any update to the document requires rewriting the entire document to disk. 
+- Any operation on a document in the `author` table requires loading all posts into memory. Note that any update to a document requires rewriting the entire document to disk. 
 - Because of the previous limitation, it's best to keep the size of
   the `posts` array to no more than a few hundred documents.
 

--- a/2-data-model/data-modeling-in-rethinkdb.md
+++ b/2-data-model/data-modeling-in-rethinkdb.md
@@ -65,9 +65,7 @@ __Advantages of using embedded arrays:__
 
 __Disadvantages of using embedded arrays:__
 
-- Any operation on an author document requires loading all posts into
-  memory. Any update to the document requires rewriting the full array
-  to disk.
+- Any operation on a document in the `author` table requires loading all posts into memory. As well, any update to the document requires rewriting the entire document to disk. At the moment, RethinkDB does not support modifying only the single value on disk. 
 - Because of the previous limitation, it's best to keep the size of
   the `posts` array to no more than a few hundred documents.
 


### PR DESCRIPTION
I think we can be a bit more clear in the fact that if a modification is made to a document, the entire document has to be rewritten to disk instead of being able to update just that single field to disk. 

This is important when considering multi-megabyte embedded documents and having to wait for that write to occur. 

@chipotle @danielmewes do you concur? 