### PR TITLE
Adding `.changes()` missing from changefeed example

### DIFF
--- a/api/javascript/manipulating-tables/changes.md
+++ b/api/javascript/manipulating-tables/changes.md
@@ -133,5 +133,5 @@ r.table('games').get(1).changes({includeStates: true}).run(conn, callback);
 __Example:__ Return all the changes to the top 10 games. This assumes the presence of a `score` secondary index on the `games` table.
 
 ```js
-r.table('games').orderBy({index: r.desc('score')}).limit(10).run(conn, callback);
+r.table('games').orderBy({index: r.desc('score')}).limit(10).changes().run(conn, callback);
 ```

--- a/api/python/manipulating-tables/changes.md
+++ b/api/python/manipulating-tables/changes.md
@@ -127,5 +127,5 @@ r.table('games').get(1).changes(include_states=True).run(conn)
 __Example:__ Return all the changes to the top 10 games. This assumes the presence of a `score` secondary index on the `games` table.
 
 ```py
-r.table('games').order_by(index=r.desc('score')).limit(10).run(conn)
+r.table('games').order_by(index=r.desc('score')).limit(10).changes().run(conn)
 ```

--- a/api/ruby/manipulating-tables/changes.md
+++ b/api/ruby/manipulating-tables/changes.md
@@ -132,5 +132,5 @@ r.table('games').get(1).changes({:include_states => true}).run(conn)
 __Example:__ Return all the changes to the top 10 games. This assumes the presence of a `score` secondary index on the `games` table.
 
 ```rb
-r.table('games').order_by({:index => r.desc('score')}).limit(10).run(conn)
+r.table('games').order_by({:index => r.desc('score')}).limit(10).changes().run(conn)
 ```


### PR DESCRIPTION
Someone alerted me to this on Gitter - https://gitter.im/rethinkdb/rethinkdb?at=55f3514f2517f9cb63145229