### PR TITLE
Fix Arch Linux build instructions

### DIFF
--- a/0-getting-started/install/arch.md
+++ b/0-getting-started/install/arch.md
@@ -56,7 +56,7 @@ $ cp -r /var/abs/community/rethinkdb/ ~
 
 Edit `PKGBUILD` to customize the build at this point.
 
-Install the dependencies, build and install the package (the `-s` flag causes `makepkg` to attempt to 
+Install the dependencies, build and install the package (the `-s` flag causes `makepkg` to attempt to
 install explicit build dependencies):
 
 ```bash
@@ -93,7 +93,7 @@ RethinkDB's `configure` script assumes the `python` executable will be Python 2 
 ```bash
 #!/bin/bash
 script=$(readlink -f -- "$1")
-case "$script" in (/home/user/rethinkdb)
+case "$script" in (/home/user/rethinkdb/*)
     exec python2 "$@"
     ;;
 esac


### PR DESCRIPTION
Arch Build instructions regarding tricking the system into choosing right version of Python interpreter unfortunately did not work for me. Here is a correct version, which I tested, taken from Arch Wiki at https://wiki.archlinux.org/index.php/Python#Dealing_with_version_problem_in_build_scripts.