### PR TITLE
Update AWS marketplace listing

### DIFF
--- a/5-deployment/paas.md
+++ b/5-deployment/paas.md
@@ -50,7 +50,7 @@ The smallest recommended instance type is `m1.small`. However, `t1.micro` works 
 
 ![Shard with the web interface](/assets/images/docs/aws/ami_setup.png)
 
-[rmp]: https://aws.amazon.com/marketplace/pp/B00E9EZ5DK
+[rmp]: https://aws.amazon.com/marketplace/pp/B013R60Q8Y
 [ys]: https://aws.amazon.com/marketplace/library
 
 {% infobox %}


### PR DESCRIPTION
Our AWS listing was moved to a new URL:
https://aws.amazon.com/marketplace/pp/B013R60Q8Y
instead of
https://aws.amazon.com/marketplace/pp/B00E9EZ5DK

The old URL is going to be removed soon, and is outdated.

@chipotle Can you merge & deploy this please when you have a moment?