### PR TITLE
Fixed wrong code block style in JS docs

### DIFF
--- a/api/javascript/index.md
+++ b/api/javascript/index.md
@@ -870,7 +870,7 @@ Used to 'zip' up the result of a join by merging the 'right' fields into 'left' 
 
 __Example:__ 'zips up' the sequence by merging the left and right fields produced by a join.
 
-```
+```js
 r.table('marvel').eqJoin('main_dc_collaborator', r.table('dc'))
     .zip().run(conn, callback)
 ```
@@ -1946,7 +1946,7 @@ Test if two or more values are not equal.
 
 __Example:__ See if a user's `role` field is not set to `administrator`. 
 
-```rb
+```js
 r.table('users').get(1)('role').ne('administrator').run(conn, callback);
 ```
 

--- a/api/javascript/joins/zip.md
+++ b/api/javascript/joins/zip.md
@@ -27,7 +27,7 @@ Used to 'zip' up the result of a join by merging the 'right' fields into 'left' 
 
 __Example:__ 'zips up' the sequence by merging the left and right fields produced by a join.
 
-```
+```js
 r.table('marvel').eqJoin('main_dc_collaborator', r.table('dc'))
     .zip().run(conn, callback)
 ```

--- a/api/python/index.md
+++ b/api/python/index.md
@@ -823,7 +823,7 @@ Used to 'zip' up the result of a join by merging the 'right' fields into 'left' 
 
 __Example:__ 'zips up' the sequence by merging the left and right fields produced by a join.
 
-```
+```py
 r.table('marvel').eq_join('main_dc_collaborator', r.table('dc')).zip().run(conn)
 ```
 

--- a/api/ruby/index.md
+++ b/api/ruby/index.md
@@ -813,7 +813,7 @@ Used to 'zip' up the result of a join by merging the 'right' fields into 'left' 
 
 __Example:__ 'zips up' the sequence by merging the left and right fields produced by a join.
 
-```
+```rb
 r.table('marvel').eq_join(:main_dc_collaborator, r.table('dc')).zip.run(conn)
 ```
 

--- a/api/ruby/joins/zip.md
+++ b/api/ruby/joins/zip.md
@@ -22,7 +22,7 @@ Used to 'zip' up the result of a join by merging the 'right' fields into 'left' 
 
 __Example:__ 'zips up' the sequence by merging the left and right fields produced by a join.
 
-```
+```rb
 r.table('marvel').eq_join(:main_dc_collaborator, r.table('dc')).zip.run(conn)
 ```
 


### PR DESCRIPTION
A few examples had the wrong/missing language specifications in the JS docs.
The same examples seem to be fine for the other languages.

@chipotle Could you review please?