### PR TITLE
Removes unnecessary backticks in python/ungroup.md

### DIFF
--- a/api/python/aggregation/ungroup.md
+++ b/api/python/aggregation/ungroup.md
@@ -72,7 +72,6 @@ r.table('games').group('player').ungroup().sample(1).run(conn)
 Result:
 
 ```py
-```java
 r.table("games").group("player").max("points").g("points").ungroup()
  .orderBy(r.desc("reduction")).run(conn);
 ```
@@ -88,7 +87,6 @@ r.table("games").group("player").max("points").g("points").ungroup()
         "reduction": 7
     }
 ]
-```
 ```
 
 Note that if you didn't call `ungroup`, you would instead select one


### PR DESCRIPTION
Makes the formatting of the examples nice again.