### PR TITLE
Additional examples for ungroup

### DIFF
--- a/api/java/aggregation/ungroup.md
+++ b/api/java/aggregation/ungroup.md
@@ -74,12 +74,6 @@ r.table("games").group("player").ungroup().sample(1).run(conn);
 Result:
 
 ```json
-```java
-r.table("games").group("player").max("points").g("points").ungroup()
- .orderBy(r.desc("reduction")).run(conn);
-```
-
-```json
 [
     {
         "group": "Bob",
@@ -90,7 +84,6 @@ r.table("games").group("player").max("points").g("points").ungroup()
         "reduction": 7
     }
 ]
-```
 ```
 
 Note that if you didn't call `ungroup`, you would instead select one
@@ -116,9 +109,21 @@ Result: (Note this is a JSON representation of a `List<GroupedResult>`; see the 
             {"id": 11, "player": "Bob", "points": 10, "type": "free"}
         ]
     }
-}
+[
 ```
 
+__Example:__ Finding the statistical mode of an array of values:
+```java
+r.expr(r.array([1,2,2,2,3,3])).group(
+  row -> row
+).ungroup().orderBy("reduction").nth(-1).bracket("group")
+```
+
+Result:
+
+```json
+2
+```
 
 
 __Example:__ Types!

--- a/api/java/aggregation/ungroup.md
+++ b/api/java/aggregation/ungroup.md
@@ -112,11 +112,11 @@ Result: (Note this is a JSON representation of a `List<GroupedResult>`; see the 
 [
 ```
 
-__Example:__ Finding the statistical mode of an array of values:
+__Example:__ Finding the arithmetic mode of an array of values:
 ```java
 r.expr(r.array([1,2,2,2,3,3])).group(
   row -> row
-).ungroup().orderBy("reduction").nth(-1).bracket("group")
+).count().ungroup().orderBy("reduction").nth(-1).bracket("group")
 ```
 
 Result:

--- a/api/javascript/aggregation/ungroup.md
+++ b/api/javascript/aggregation/ungroup.md
@@ -51,7 +51,7 @@ r.table('games')
 
 <!-- stop -->
 
-Result: 
+Result:
 
 ```js
 [
@@ -114,7 +114,16 @@ Result:
 }
 ```
 
+__Example:__ Finding the arithmetic mode of an array of values:
+```javascript
+r.expr([1,2,2,2,3,3]).group(r.row).count().ungroup().orderBy('reduction').nth(-1)('group')
+```
 
+Result:
+
+```json
+2
+```
 
 __Example:__ Types!
 

--- a/api/python/aggregation/ungroup.md
+++ b/api/python/aggregation/ungroup.md
@@ -48,7 +48,7 @@ r.table('games')
 
 <!-- stop -->
 
-Result: 
+Result:
 
 ```py
 [
@@ -101,6 +101,17 @@ Result:
         {"id": 11, "player": "Bob", "points": 10, "type": "free"}
     ]
 }
+```
+
+__Example:__ Finding the arithmetic mode of an array of values:
+```python
+r.expr([1,2,2,2,3,3]).group(r.row).count().ungroup().order_by('reduction').nth(-1)['group']
+```
+
+Result:
+
+```json
+2
 ```
 
 __Example:__ Types!

--- a/api/ruby/aggregation/ungroup.md
+++ b/api/ruby/aggregation/ungroup.md
@@ -48,7 +48,7 @@ r.table('games')
 
 <!-- stop -->
 
-Result: 
+Result:
 
 ```rb
 [
@@ -101,6 +101,17 @@ Result:
         {"id" => 11, "player" => "Bob", "points" => 10, "type" => "free"}
     ]
 }
+```
+
+__Example:__ Finding the arithmetic mode of an array of values:
+```ruby
+r.expr([1,2,2,2,3,3]).group(){|row| row}.count().ungroup().order_by('reduction').nth(-1)['group']
+```
+
+Result:
+
+```json
+2
 ```
 
 __Example:__ Types!


### PR DESCRIPTION
Added an example for `ungroup`. It might be a little out-of-place, but it demonstrates using `ungroup` along with a large number of rethink keywords.

Also cleans up formatting errors in the [upgroup java page](http://rethinkdb.com/api/java/ungroup/).