### PR TITLE
Fixes a small parameter error on "Install RethinkDB on Windows" Resolves #1025

### DIFF
--- a/0-getting-started/install/windows.md
+++ b/0-getting-started/install/windows.md
@@ -45,7 +45,7 @@ To start with a specific data directory:
 
 To specify a server name and another cluster to join:
 
-    rethinkdb.exe -n jarvis --j cluster.example.com
+    rethinkdb.exe -n jarvis -j cluster.example.com
 
 # Compile from source #
 


### PR DESCRIPTION
Was trying RehtinkDB on Windows, noticed issue #1025, resolves small `-j` parameter sign error.
Fixes #1025 