### PR TITLE
add libssl-dev to list of dependencies

### DIFF
--- a/0-getting-started/install/raspbian.md
+++ b/0-getting-started/install/raspbian.md
@@ -18,7 +18,7 @@ Install the main dependencies:
 
 ```
 sudo apt-get install g++ protobuf-compiler libprotobuf-dev \
-                     libboost-dev curl m4 wget
+                     libboost-dev curl m4 wget libssl-dev
 ```
 
 ## Prepare the raspberrypi ##


### PR DESCRIPTION
I was following the installation instructions on a brand new Raspbian and got stuck with this error:
```fatal error: openssl/sha.h: No such file or directory```

Turns out, I just had to install another dependency:
```sudo apt-get install libssl-dev```

OT: I was able to successfully install rethinkdb after that. The compilation process took **several** hours on the latest Raspberry PI 3 model, I don't know if this is something we should mention in the docs.