### PR TITLE
Add `--fetch openssl` to OS X build instructions

### DIFF
--- a/0-getting-started/install/osx.md
+++ b/0-getting-started/install/osx.md
@@ -47,7 +47,7 @@ Kick off the build process:
 
 ```bash
 cd rethinkdb-{{site.version.full}}
-./configure --allow-fetch
+./configure --allow-fetch --fetch openssl
 make
 ```
 


### PR DESCRIPTION
Building on OS X usually requires this flag now.