### PR TITLE
Clearer indentation on function serialization

### DIFF
--- a/7-developing/writing-drivers.md
+++ b/7-developing/writing-drivers.md
@@ -315,10 +315,10 @@ The function would be serialized as:
 
     [FUNC, 
      [[MAKE_ARRAY, [1, 2, 3]],
-       [ADD,
-        [[VAR, [1]],
-         [VAR, [2]],
-         [VAR, [3]]]]]]
+      [ADD,
+       [[VAR, [1]],
+        [VAR, [2]],
+        [VAR, [3]]]]]]
 
     // FUNC = 69, MAKE_ARRAY = 2, ADD = 24, VAR = 10 (from ql2.proto)
 


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

The current indentation on function serialization makes it look as if `[ADD ...]` belongs to `MAKE_ARRAY` as opposed to belonging to `FUNC`. This change de-indents it by one space to make it clearer.