### PR TITLE
Standardise JavaScript code examples

### DIFF
--- a/api/javascript/accessing-rql/close.md
+++ b/api/javascript/accessing-rql/close.md
@@ -28,7 +28,7 @@ A noreply query is executed by passing the `noreply` option to the [run](/api/ja
 
 __Example:__ Close an open connection, waiting for noreply writes to finish.
 
-```js
+```javascript
 conn.close(function(err) { if (err) throw err; })
 ```
 
@@ -36,7 +36,7 @@ conn.close(function(err) { if (err) throw err; })
 
 Alternatively, you can use promises.
 
-```js
+```javascript
 p = conn.close();
 p.then(function() {
     // `conn` is now closed
@@ -47,13 +47,13 @@ p.then(function() {
 
 __Example:__ Close an open connection immediately.
 
-```js
+```javascript
 conn.close({noreplyWait: false}, function(err) { if (err) throw err; })
 ```
 
 Alternatively, you can use promises.
 
-```js
+```javascript
 conn.close({noreplyWait: false}).then(function() {
     // conn is now closed
 }).error(function(err) { 

--- a/api/javascript/accessing-rql/connect.md
+++ b/api/javascript/accessing-rql/connect.md
@@ -43,7 +43,7 @@ If the connection cannot be established, a `ReqlDriverError` will be passed to t
 
 The returned connection object will have two properties on it containing the connection's port and address:
 
-```js
+```javascript
 conn.clientPort;
 conn.clientAddress;
 ```
@@ -62,7 +62,7 @@ Alternatively, you may use RethinkDB's built-in [TLS support][tls].
 
 __Example:__ Open a connection using the default host and port, specifying the default database.
 
-```js
+```javascript
 r.connect({
     db: 'marvel'
 }, function(err, conn) {
@@ -72,13 +72,13 @@ r.connect({
 
 If no callback is provided, a promise will be returned.
 
-```js
+```javascript
 var promise = r.connect({db: 'marvel'});
 ```
 
 __Example:__ Open a new connection to the database.
 
-```js
+```javascript
 r.connect({
     host: 'localhost',
     port: 28015,
@@ -90,7 +90,7 @@ r.connect({
 
 Alternatively, you can use promises.
 
-```js
+```javascript
 var p = r.connect({
     host: 'localhost',
     port: 28015,
@@ -105,7 +105,7 @@ p.then(function(conn) {
 
 __Example:__ Open a new connection to the database, specifying a user/password combination for authentication.
 
-```js
+```javascript
 r.connect({
     host: 'localhost',
     port: 28015,
@@ -119,7 +119,7 @@ r.connect({
 
 __Example:__ Open a new connection to the database using an SSL proxy.
 
-```js
+```javascript
 var fs = require('fs');
 fs.readFile('/path/to/cert', function (err, caCert) {
     if (!err) {

--- a/api/javascript/accessing-rql/event_emitter.md
+++ b/api/javascript/accessing-rql/event_emitter.md
@@ -51,7 +51,7 @@ Four events are emitted: `connect`, `close`, `timeout` and `error`.
 __Example:__ Monitor the connection state with events.
 
 
-```js
+```javascript
 r.connect({}, function(err, conn) {
     if (err) throw err;
 
@@ -69,7 +69,7 @@ r.connect({}, function(err, conn) {
 
 __Example:__ As in Node, `on` is a synonym for `addListener`.
 
-```js
+```javascript
 conn.on('close', function() {
     cleanup();
 });

--- a/api/javascript/accessing-rql/noreply_wait.md
+++ b/api/javascript/accessing-rql/noreply_wait.md
@@ -29,7 +29,7 @@ If no callback is provided, a promise will be returned.
 __Example:__ We have previously run queries with the `noreply` argument set to `true`. Now
 wait until the server has processed them.
 
-```js
+```javascript
 conn.noreplyWait(function(err) { ... })
 ```
 
@@ -37,7 +37,7 @@ conn.noreplyWait(function(err) { ... })
 
 Alternatively, you can use promises.
 
-```js
+```javascript
 conn.noreplyWait().then(function() {
     // all queries have been processed
 }).error(function(err) {

--- a/api/javascript/accessing-rql/r.md
+++ b/api/javascript/accessing-rql/r.md
@@ -20,6 +20,6 @@ The top-level ReQL namespace.
 
 __Example:__ Set up your top-level namespace.
 
-```js
+```javascript
 var r = require('rethinkdb');
 ```

--- a/api/javascript/accessing-rql/reconnect.md
+++ b/api/javascript/accessing-rql/reconnect.md
@@ -30,7 +30,7 @@ A noreply query is executed by passing the `noreply` option to the [run](/api/ja
 
 __Example:__ Cancel outstanding requests/queries that are no longer needed.
 
-```js
+```javascript
 conn.reconnect({noreplyWait: false}, function(error, connection) { ... })
 ```
 
@@ -38,7 +38,7 @@ conn.reconnect({noreplyWait: false}, function(error, connection) { ... })
 
 Alternatively, you can use promises.
 
-```js
+```javascript
 conn.reconnect({noreplyWait: false}).then(function(conn) {
     // the outstanding queries were canceled and conn is now available again
 }).error(function(errror) {

--- a/api/javascript/accessing-rql/run.md
+++ b/api/javascript/accessing-rql/run.md
@@ -54,7 +54,7 @@ If no callback is provided, a promise will be returned.
 __Example:__ Run a query on the connection `conn` and log each row in
 the result to the console.
 
-```js
+```javascript
 r.table('marvel').run(conn, function(err, cursor) {
     cursor.each(console.log);
 })
@@ -63,7 +63,7 @@ r.table('marvel').run(conn, function(err, cursor) {
 __Example:__ Run a query on the connection `conn` and retrieve all the rows in an
 array.
 
-```js
+```javascript
 r.table('marvel').run(conn, function(err, cursor) {
     if (err) {
         // process error
@@ -83,7 +83,7 @@ r.table('marvel').run(conn, function(err, cursor) {
 
 Alternatively, you can use promises.
 
-```js
+```javascript
 r.table('marvel').run(conn).then(function(cursor) {
     return cursor.toArray()
 }).then(function(results) {
@@ -100,7 +100,7 @@ pass a flag allowing out of date data in an options object. Settings
 for individual tables will supercede this global setting for all
 tables in the query.
 
-```js
+```javascript
 r.table('marvel').run(conn, {readMode: 'outdated'}, function (err, cursor) {
     ...
 });
@@ -110,7 +110,7 @@ __Example:__ If you just want to send a write and forget about it, you
 can set `noreply` to true in the options. In this case `run` will
 return immediately.
 
-```js
+```javascript
 r.table('marvel').run(conn, {noreply: true}, function (err, cursor) {
     ...
 });
@@ -120,7 +120,7 @@ __Example:__ If you want to specify whether to wait for a write to be
 written to disk (overriding the table's default settings), you can set
 `durability` to `'hard'` or `'soft'` in the options.
 
-```js
+```javascript
 r.table('marvel')
     .insert({ superhero: 'Iron Man', superpower: 'Arc Reactor' })
     .run(conn, {noreply: true, durability: 'soft'}, function (err, cursor) {
@@ -134,7 +134,7 @@ native date object, you can pass a `time_format` flag to prevent it
 with two fields (`epoch_time` and `$reql_type$`) instead of a native date
 object.
 
-```js
+```javascript
 r.now().run(conn, {timeFormat: "raw"}, function (err, result) {
     ...
 });
@@ -142,7 +142,7 @@ r.now().run(conn, {timeFormat: "raw"}, function (err, result) {
 
 __Example:__ Specify the database to use for the query.
 
-```js
+```javascript
 r.table('marvel').run(conn, {db: 'heroes'}).then(function(cursor) {
     return cursor.toArray()
 }).then(function(results) {
@@ -154,13 +154,13 @@ r.table('marvel').run(conn, {db: 'heroes'}).then(function(cursor) {
 
 This is equivalent to using the `db` command to specify the database:
 
-```js
+```javascript
 r.db('heroes').table('marvel').run(conn) ...
 ```
 
 __Example:__ Change the batching parameters for this query.
 
-```js
+```javascript
 r.table('marvel').run(conn, {
     maxBatchRows: 16,
     maxBatchBytes: 2048

--- a/api/javascript/accessing-rql/server.md
+++ b/api/javascript/accessing-rql/server.md
@@ -29,7 +29,7 @@ The `server` command returns either two or three fields:
 
 __Example:__ Return server information.
 
-```js
+```javascript
 conn.server(callback);
 
 // Result passed to callback

--- a/api/javascript/accessing-rql/use.md
+++ b/api/javascript/accessing-rql/use.md
@@ -25,7 +25,7 @@ Change the default database on this connection.
 __Example:__ Change the default database so that we don't need to
 specify the database when referencing a table.
 
-```js
+```javascript
 conn.use('marvel')
 r.table('heroes').run(conn, ...) // refers to r.db('marvel').table('heroes')
 ```

--- a/api/javascript/administration/config.md
+++ b/api/javascript/administration/config.md
@@ -24,7 +24,7 @@ The `config` command is a shorthand way to access the `table_config` or `db_conf
 
 __Example:__ Get the configuration for the `users` table.
 
-```js
+```javascript
 > r.table('users').config().run(conn, callback);
 ```
 
@@ -32,7 +32,7 @@ __Example:__ Get the configuration for the `users` table.
 
 Example return:
 
-```js
+```javascript
 {
     "id": "31c92680-f70c-4a4b-a49e-b238eb12c023",
     "name": "users",
@@ -58,6 +58,6 @@ Example return:
 
 __Example:__ Change the write acknowledgement requirement of the `users` table.
 
-```js
+```javascript
 > r.table('users').config().update({write_acks: 'single'}).run(conn, callback);
 ```

--- a/api/javascript/administration/grant.md
+++ b/api/javascript/administration/grant.md
@@ -47,6 +47,7 @@ The `grant` command returns an object of the following form:
             "old_val": { original permissions }
         }
     ]
+}
 ```
 
 The `granted` field will always be `1`, and the `permissions_changes` list will have one object, describing the new permissions values and the old values they were changed from (which may be `null`).
@@ -63,7 +64,7 @@ For a full description of permissions, read [Permissions and user accounts][pa].
 
 __Example:__ Grant the `chatapp` user account read and write permissions on the `users` database.
 
-```js
+```javascript
 r.db('users').grant('chatapp', {read: true, write: true}).run(conn, callback);
 
 // Result passed to callback
@@ -79,7 +80,7 @@ r.db('users').grant('chatapp', {read: true, write: true}).run(conn, callback);
 
 __Example:__ Deny write permissions from the `chatapp` account for the `admin` table.
 
-```js
+```javascript
 r.db('users').table('admin').grant('chatapp', {write: false}).run(conn, callback);
 ```
 
@@ -87,7 +88,7 @@ This will override the `write: true` permissions granted in the first example, b
 
 __Example:__ Delete a table-level permission for the `chatapp` account.
 
-```js
+```javascript
 r.db('users').table('admin').grant('chatapp', {write: null}).run(conn, callback);
 ```
 
@@ -95,7 +96,7 @@ By specifying `null`, the table scope `write` permission is removed, and will ag
 
 __Example:__ Grant `chatapp` the ability to use HTTP connections.
 
-```js
+```javascript
 r.grant('chatapp', {connect: true}).run(conn, callback);
 ```
 
@@ -104,6 +105,6 @@ This grant can only be given on a global level.
 
 __Example:__ Grant a `monitor` account read-only access to all databases.
 
-```js
+```javascript
 r.grant('monitor', {read: true}).run(conn, callback);
 ```

--- a/api/javascript/administration/rebalance.md
+++ b/api/javascript/administration/rebalance.md
@@ -43,7 +43,7 @@ See the [status](/api/javascript/status) command for an explanation of the objec
 
 __Example:__ Rebalance a table.
 
-```js
+```javascript
 > r.table('superheroes').rebalance().run(conn, callback);
 ```
 
@@ -51,7 +51,7 @@ __Example:__ Rebalance a table.
 
 Example return:
 
-```js
+```javascript
 {
   "rebalanced": 1,
   "status_changes": [

--- a/api/javascript/administration/reconfigure.md
+++ b/api/javascript/administration/reconfigure.md
@@ -53,7 +53,7 @@ Read [Sharding and replication](/docs/sharding-and-replication/) for a complete 
 
 __Example:__ Reconfigure a table.
 
-```js
+```javascript
 > r.table('superheroes').reconfigure({shards: 2, replicas: 1}).run(conn, callback);
 ```
 
@@ -61,7 +61,7 @@ __Example:__ Reconfigure a table.
 
 Example return:
 
-```js
+```javascript
 {
   "reconfigured": 1,
   "config_changes": [
@@ -114,7 +114,7 @@ Example return:
 
 __Example:__ Reconfigure a table, specifying replicas by server tags.
 
-```js
+```javascript
 > r.table('superheroes').reconfigure({shards: 2, replicas: {wooster: 1, wayne: 1}, primaryReplicaTag: 'wooster'}).run(conn, callback);
 // Result passed to callback
 {
@@ -199,7 +199,7 @@ __Note:__ `emergencyRepair` may only be used on individual tables, not on databa
 
 __Example:__ Perform an emergency repair on a table.
 
-```js
+```javascript
 r.table('superheroes').reconfigure(
   {emergencyRepair: "unsafe_rollback"}
 ).run(conn, callback);

--- a/api/javascript/administration/status.md
+++ b/api/javascript/administration/status.md
@@ -29,7 +29,7 @@ The return value is an object providing information about the table's shards, re
 
 __Example:__ Get a table's status.
 
-```js
+```javascript
 > r.table('superheroes').status().run(conn, callback);
 ```
 
@@ -37,7 +37,7 @@ __Example:__ Get a table's status.
 
 Example return:
 
-```js
+```javascript
 {
   "db": "database",
   "id": "5cb35225-81b2-4cec-9eef-bfad15481265",

--- a/api/javascript/administration/wait.md
+++ b/api/javascript/administration/wait.md
@@ -36,7 +36,7 @@ Versions of RethinkDB prior to 2.3 allowed `wait` to be called without a table o
 
 __Example:__ Wait on a table to be ready.
 
-```js
+```javascript
 > r.table('superheroes').wait().run(conn, callback);
 // Result passed to callback
 { "ready": 1 }

--- a/api/javascript/aggregation/avg.md
+++ b/api/javascript/aggregation/avg.md
@@ -37,20 +37,20 @@ can handle this case with `default`.
 
 __Example:__ What's the average of 3, 5, and 7?
 
-```js
+```javascript
 r.expr([3, 5, 7]).avg().run(conn, callback)
 ```
 
 __Example:__ What's the average number of points scored in a game?
 
-```js
+```javascript
 r.table('games').avg('points').run(conn, callback)
 ```
 
 __Example:__ What's the average number of points scored in a game,
 counting bonus points?
 
-```js
+```javascript
 r.table('games').avg(function(game) {
     return game('points').add(game('bonus_points'))
 }).run(conn, callback)
@@ -60,6 +60,6 @@ __Example:__ What's the average number of points scored in a game?
 (But return `null` instead of raising an error if there are no games where
 points have been scored.)
 
-```js
+```javascript
 r.table('games').avg('points').default(null).run(conn, callback)
 ```

--- a/api/javascript/aggregation/contains.md
+++ b/api/javascript/aggregation/contains.md
@@ -30,13 +30,13 @@ Values and predicates may be mixed freely in the argument list.
 
 __Example:__ Has Iron Man ever fought Superman?
 
-```js
+```javascript
 r.table('marvel').get('ironman')('opponents').contains('superman').run(conn, callback);
 ```
 
 __Example:__ Has Iron Man ever defeated Superman in battle?
 
-```js
+```javascript
 r.table('marvel').get('ironman')('battles').contains(function (battle) {
     return battle('winner').eq('ironman').and(battle('loser').eq('superman'));
 }).run(conn, callback);
@@ -44,7 +44,7 @@ r.table('marvel').get('ironman')('battles').contains(function (battle) {
 
 __Example:__ Return all heroes who have fought _both_ Loki and the Hulk.
 
-```js
+```javascript
 r.table('marvel').filter(function (hero) {
   return hero('opponents').contains('loki', 'hulk');
 }).run(conn, callback);
@@ -52,7 +52,7 @@ r.table('marvel').filter(function (hero) {
 
 __Example:__ Use `contains` with a predicate function to simulate an `or`. Return the Marvel superheroes who live in Detroit, Chicago or Hoboken.
 
-```js
+```javascript
 r.table('marvel').filter(function(hero) {
     return r.expr(['Detroit', 'Chicago', 'Hoboken']).contains(hero('city'))
 }).run(conn, callback);

--- a/api/javascript/aggregation/count.md
+++ b/api/javascript/aggregation/count.md
@@ -36,25 +36,25 @@ When `count` is called on a sequence with a predicate value or function, it retu
 
 __Example:__ Count the number of users.
 
-```js
+```javascript
 r.table('users').count().run(conn, callback);
 ```
 
 __Example:__ Count the number of 18 year old users.
 
-```js
+```javascript
 r.table('users')('age').count(18).run(conn, callback);
 ```
 
 __Example:__ Count the number of users over 18.
 
-```js
+```javascript
 r.table('users')('age').count(function(age) { 
     return age.gt(18)
 }).run(conn, callback);
 ```
 
-```js
+```javascript
 r.table('users').count(function(user) {
     return user('age').gt(18)
 }).run(conn, callback)
@@ -62,7 +62,7 @@ r.table('users').count(function(user) {
 
 __Example:__ Return the length of a Unicode string.
 
-```js
+```javascript
 r.expr("こんにちは").count().run(conn, callback);
 // Result passed to callback
 5

--- a/api/javascript/aggregation/distinct.md
+++ b/api/javascript/aggregation/distinct.md
@@ -35,7 +35,7 @@ While `distinct` can be called on a table without an index, the only effect will
 
 __Example:__ Which unique villains have been vanquished by Marvel heroes?
 
-```js
+```javascript
 r.table('marvel').concatMap(function(hero) {
     return hero('villainList')
 }).distinct().run(conn, callback)
@@ -43,13 +43,13 @@ r.table('marvel').concatMap(function(hero) {
 
 __Example:__ Topics in a table of messages have a secondary index on them, and more than one message can have the same topic. What are the unique topics in the table?
 
-```js
+```javascript
 r.table('messages').distinct({index: 'topics'}).run(conn, callback)
 ```
 
 The above structure is functionally identical to:
 
-```js
+```javascript
 r.table('messages')('topics').distinct().run(conn, callback)
 ```
 

--- a/api/javascript/aggregation/fold.md
+++ b/api/javascript/aggregation/fold.md
@@ -55,7 +55,7 @@ finalEmit(accumulator | base) &rarr; array
 
 __Example:__ Concatenate words from a list.
 
-```js
+```javascript
 r.table('words').orderBy('id').fold('', function (acc, word) {
     return acc.add(r.branch(acc.eq(''), '', ', ')).add(word);
 }).run(conn, callback);
@@ -65,7 +65,7 @@ r.table('words').orderBy('id').fold('', function (acc, word) {
 
 __Example:__ Return every other row in a table.
 
-```js
+```javascript
 r.table('even_things').fold(0, function(acc, row) {
     return acc.add(1);
 }, {emit:
@@ -79,7 +79,7 @@ The first function increments the accumulator each time it's called, starting at
 
 __Example:__ Compute a five-day running average for a weight tracker.
 
-```js
+```javascript
 r.table('tracker').filter({name: 'bob'}).orderBy('date')('weight').fold(
     [],
     function (acc, row) { return r.expr([row]).add(acc).limit(5); },

--- a/api/javascript/aggregation/group.md
+++ b/api/javascript/aggregation/group.md
@@ -35,7 +35,7 @@ With the `multi` flag single documents can be assigned to multiple groups, simil
 
 Suppose that the table `games` has the following data:
 
-```js
+```javascript
 [
     {id: 2, player: "Bob", points: 15, type: "ranked"},
     {id: 5, player: "Alice", points: 7, type: "free"},
@@ -46,7 +46,7 @@ Suppose that the table `games` has the following data:
 
 __Example:__ Group games by player.
 
-```js
+```javascript
 > r.table('games').group('player').run(conn, callback)
 
 // Result passed to callback
@@ -75,7 +75,7 @@ sub-streams, producing grouped data.
 
 __Example:__ What is each player's best game?
 
-```js
+```javascript
 > r.table('games').group('player').max('points').run(conn, callback)
 
 // Result passed to callback
@@ -96,7 +96,7 @@ producing more grouped data.
 
 __Example:__ What is the maximum number of points scored by each player?
 
-```js
+```javascript
 > r.table('games').group('player').max('points')('points').run(conn, callback)
 
 // Result passed to callback
@@ -117,7 +117,7 @@ You can also group by more than one field.
 __Example:__ What is the maximum number of points scored by each
 player for each game type?
 
-```js
+```javascript
 > r.table('games').group('player', 'type').max('points')('points').run(conn, callback)
 
 // Result passed to callback
@@ -143,7 +143,7 @@ __Example:__ What is the maximum number of points scored by each
 player for each game type?
 
 
-```js
+```javascript
 > r.table('games')
     .group(function(game) {
         return game.pluck('player', 'type')
@@ -170,7 +170,7 @@ Using a function, you can also group by date on a ReQL [date field](/docs/dates-
 
 __Example:__ How many matches have been played this year by month?
 
-```js
+```javascript
 > r.table('matches').group(
       [r.row('date').year(), r.row('date').month()]
   ).count().run(conn, callback)
@@ -201,7 +201,7 @@ You can also group on an index (primary key or secondary).
 __Example:__ What is the maximum number of points scored by game type?
 
 
-```js
+```javascript
 > r.table('games').group({index:'type'}).max('points')('points').run(conn, callback)
 
 // Result passed to callback
@@ -221,7 +221,7 @@ __Example:__ What is the maximum number of points scored by game type?
 
 Suppose that the table `games2` has the following data:
 
-```js
+```javascript
 [
     { id: 1, matches: {'a': [1, 2, 3], 'b': [4, 5, 6]} },
     { id: 2, matches: {'b': [100], 'c': [7, 8, 9]} },
@@ -231,7 +231,7 @@ Suppose that the table `games2` has the following data:
 
 Using the `multi` option we can group data by match A, B or C.
 
-```js
+```javascript
 r.table('games2').group(r.row('matches').keys(), {multi: true}).run(conn, callback);
 // Result passed to callback
 [
@@ -254,7 +254,7 @@ r.table('games2').group(r.row('matches').keys(), {multi: true}).run(conn, callba
 
 __Example:__ Use [map](/api/javascript/map) and [sum](/api/javascript/sum) to get the total points scored for each match.
 
-```js
+```javascript
 r.table('games2').group(r.row('matches').keys(), {multi: true}).ungroup().map(
     function (doc) {
         return { match: doc('group'), total: doc('reduction').sum(
@@ -283,7 +283,7 @@ grouped data into an array of objects representing the groups.
 
 __Example:__ Ungrouping grouped data.
 
-```js
+```javascript
 > r.table('games').group('player').max('points')('points').ungroup().run(conn, callback)
 
 // Result passed to callback
@@ -305,7 +305,7 @@ grouped data into a table.
 __Example:__ What is the maximum number of points scored by each
 player, with the highest scorers first?
 
-```js
+```javascript
 > r.table('games')
    .group('player').max('points')('points')
    .ungroup().orderBy(r.desc('reduction')).run(conn, callback)
@@ -335,7 +335,7 @@ argument to `run`:
 
 __Example:__ Get back the raw `GROUPED_DATA` pseudotype.
 
-```js
+```javascript
 > r.table('games').group('player').avg('points').run(conn, {groupFormat:'raw'}, callback)
 
 // Result passed to callback
@@ -350,7 +350,7 @@ __Example:__ Get back the raw `GROUPED_DATA` pseudotype.
 
 Not passing the `group_format` flag would return:
 
-```js
+```javascript
 [
     {
         group: "Alice":
@@ -383,7 +383,7 @@ query.  Below are efficient and inefficient examples.
 
 __Example:__ Efficient operation.
 
-```js
+```javascript
 // r.table('games').group('player').typeOf().run(conn, callback)
 // Returns "GROUPED_STREAM"
 r.table('games').group('player').min('points').run(conn, callback) // EFFICIENT
@@ -391,7 +391,7 @@ r.table('games').group('player').min('points').run(conn, callback) // EFFICIENT
 
 __Example:__ Inefficient operation.
 
-```js
+```javascript
 // r.table('games').group('player').orderBy('score').typeOf().run(conn, callback)
 // Returns "GROUPED_DATA"
 r.table('games').group('player').orderBy('score').nth(0).run(conn, callback) // INEFFICIENT
@@ -412,7 +412,7 @@ would fail for tables with more than 100,000 rows without changing the `arrayLim
 __Example:__ What is the maximum number of points scored by each
 player in free games?
 
-```js
+```javascript
 > r.table('games').filter( r.row('type').eq('free'))
     .group('player').max('points')('points')
     .run(conn, callback)
@@ -432,7 +432,7 @@ player in free games?
 
 __Example:__ What is each player's highest even and odd score?
 
-```js
+```javascript
 r.table('games')
     .group('name', function(game) {
         return game('points').mod(2)

--- a/api/javascript/aggregation/max.md
+++ b/api/javascript/aggregation/max.md
@@ -41,25 +41,25 @@ Calling `max` on an empty sequence will throw a non-existence error; this can be
 
 __Example:__ Return the maximum value in the list `[3, 5, 7]`.
 
-```js
+```javascript
 r.expr([3, 5, 7]).max().run(conn, callback);
 ```
 
 __Example:__ Return the user who has scored the most points.
 
-```js
+```javascript
 r.table('users').max('points').run(conn, callback);
 ```
 
 __Example:__ The same as above, but using a secondary index on the `points` field.
 
-```js
+```javascript
 r.table('users').max({index: 'points'}).run(conn, callback);
 ```
 
 __Example:__ Return the user who has scored the most points, adding in bonus points from a separate field using a function.
 
-```js
+```javascript
 r.table('users').max(function(user) {
     return user('points').add(user('bonusPoints'));
 }).run(conn, callback);
@@ -67,12 +67,12 @@ r.table('users').max(function(user) {
 
 __Example:__ Return the highest number of points any user has ever scored. This returns the value of that `points` field, not a document.
 
-```js
+```javascript
 r.table('users').max('points')('points').run(conn, callback);
 ```
 
 __Example:__ Return the user who has scored the most points, but add a default `null` return value to prevent an error if no user has ever scored points.
 
-```js
+```javascript
 r.table('users').max('points').default(null).run(conn, callback);
 ```

--- a/api/javascript/aggregation/min.md
+++ b/api/javascript/aggregation/min.md
@@ -41,25 +41,25 @@ Calling `min` on an empty sequence will throw a non-existence error; this can be
 
 __Example:__ Return the minimum value in the list `[3, 5, 7]`.
 
-```js
+```javascript
 r.expr([3, 5, 7]).min().run(conn, callback);
 ```
 
 __Example:__ Return the user who has scored the fewest points.
 
-```js
+```javascript
 r.table('users').min('points').run(conn, callback);
 ```
 
 __Example:__ The same as above, but using a secondary index on the `points` field.
 
-```js
+```javascript
 r.table('users').min({index: 'points'}).run(conn, callback);
 ```
 
 __Example:__ Return the user who has scored the fewest points, adding in bonus points from a separate field using a function.
 
-```js
+```javascript
 r.table('users').min(function(user) {
     return user('points').add(user('bonusPoints'));
 }).run(conn, callback);
@@ -67,12 +67,12 @@ r.table('users').min(function(user) {
 
 __Example:__ Return the smallest number of points any user has ever scored. This returns the value of that `points` field, not a document.
 
-```js
+```javascript
 r.table('users').min('points')('points').run(conn, callback);
 ```
 
 __Example:__ Return the user who has scored the fewest points, but add a default `null` return value to prevent an error if no user has ever scored points.
 
-```js
+```javascript
 r.table('users').min('points').default(null).run(conn, callback);
 ```

--- a/api/javascript/aggregation/reduce.md
+++ b/api/javascript/aggregation/reduce.md
@@ -45,7 +45,7 @@ If the sequence has only one element, the first element will be returned.
 
 __Example:__ Return the number of documents in the table `posts`.
 
-```js
+```javascript
 r.table("posts").map(function(doc) {
     return 1;
 }).reduce(function(left, right) {
@@ -60,7 +60,7 @@ __Example:__ Suppose that each `post` has a field `comments` that is an array of
 comments.  
 Return the number of comments for all posts.
 
-```js
+```javascript
 r.table("posts").map(function(doc) {
     return doc("comments").count();
 }).reduce(function(left, right) {
@@ -74,7 +74,7 @@ __Example:__ Suppose that each `post` has a field `comments` that is an array of
 comments.  
 Return the maximum number comments per post.
 
-```js
+```javascript
 r.table("posts").map(function(doc) {
     return doc("comments").count();
 }).reduce(function(left, right) {

--- a/api/javascript/aggregation/sum.md
+++ b/api/javascript/aggregation/sum.md
@@ -36,20 +36,20 @@ Returns `0` when called on an empty sequence.
 
 __Example:__ What's 3 + 5 + 7?
 
-```js
+```javascript
 r.expr([3, 5, 7]).sum().run(conn, callback)
 ```
 
 __Example:__ How many points have been scored across all games?
 
-```js
+```javascript
 r.table('games').sum('points').run(conn, callback)
 ```
 
 __Example:__ How many points have been scored across all games,
 counting bonus points?
 
-```js
+```javascript
 r.table('games').sum(function(game) {
     return game('points').add(game('bonus_points'))
 }).run(conn, callback)

--- a/api/javascript/aggregation/ungroup.md
+++ b/api/javascript/aggregation/ungroup.md
@@ -31,7 +31,7 @@ data explorer.
 
 Suppose that the table `games` has the following data:
 
-```js
+```javascript
 [
     {id: 2, player: "Bob", points: 15, type: "ranked"},
     {id: 5, player: "Alice", points: 7, type: "free"},
@@ -43,7 +43,7 @@ Suppose that the table `games` has the following data:
 __Example:__ What is the maximum number of points scored by each
 player, with the highest scorers first?
 
-```js
+```javascript
 r.table('games')
    .group('player').max('points')('points')
    .ungroup().orderBy(r.desc('reduction')).run(conn, callback)
@@ -53,7 +53,7 @@ r.table('games')
 
 Result:
 
-```js
+```javascript
 [
     {
         group: "Bob",
@@ -68,13 +68,13 @@ Result:
 
 __Example:__ Select one random player and all their games.
 
-```js
+```javascript
 r.table('games').group('player').ungroup().sample(1).run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 [
     {
         group: "Bob",
@@ -91,13 +91,13 @@ Result:
 Note that if you didn't call `ungroup`, you would instead select one
 random game from each player:
 
-```js
+```javascript
 r.table('games').group('player').sample(1).run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 [
     {
         group: "Alice",
@@ -128,7 +128,7 @@ Result:
 
 __Example:__ Types!
 
-```js
+```javascript
 r.table('games').group('player').typeOf().run(conn, callback) // Returns "GROUPED_STREAM"
 r.table('games').group('player').ungroup().typeOf().run(conn, callback) // Returns "ARRAY"
 r.table('games').group('player').avg('points').run(conn, callback) // Returns "GROUPED_DATA"

--- a/api/javascript/control-structures/args.md
+++ b/api/javascript/control-structures/args.md
@@ -24,7 +24,7 @@ This is analogous to using **apply** in JavaScript. (However, note that `args` e
 
 __Example:__ Get Alice and Bob from the table `people`.
 
-```js
+```javascript
 r.table('people').getAll('Alice', 'Bob').run(conn, callback)
 // or
 r.table('people').getAll(r.args(['Alice', 'Bob'])).run(conn, callback)
@@ -32,14 +32,14 @@ r.table('people').getAll(r.args(['Alice', 'Bob'])).run(conn, callback)
 
 __Example:__ Get all of Alice's children from the table `people`.
 
-```js
+```javascript
 // r.table('people').get('Alice') returns {id: 'Alice', children: ['Bob', 'Carol']}
 r.table('people').getAll(r.args(r.table('people').get('Alice')('children'))).run(conn, callback)
 ```
 
 __Note:__ When using `r.args` with a command that takes optional arguments, you must not include the optional arguments inside the `args` array.
 
-```js
+```javascript
 // Wrong!
 r.table('posts').indexCreate(r.args(['tags', {multi: true}]))
 // Right

--- a/api/javascript/control-structures/binary.md
+++ b/api/javascript/control-structures/binary.md
@@ -32,7 +32,7 @@ Only a limited subset of ReQL commands may be chained after `binary`:
 
 __Example:__ Save an avatar image to a existing user record.
 
-```js
+```javascript
 var fs = require('fs');
 fs.readFile('./defaultAvatar.png', function (err, avatarImage) {
     if (err) {
@@ -48,7 +48,7 @@ fs.readFile('./defaultAvatar.png', function (err, avatarImage) {
 
 __Example:__ Get the size of an existing avatar image.
 
-```js
+```javascript
 r.table('users').get(100)('avatar').count().run(conn, callback);
 // result returned to callback
 14156

--- a/api/javascript/control-structures/branch.md
+++ b/api/javascript/control-structures/branch.md
@@ -27,13 +27,13 @@ The `branch` command takes 2n+1 arguments: pairs of conditional expressions and 
 
 You may call `branch` infix style on the first test. (See the second example for an illustration.)
 
-```
+```javascript
 r.branch(test1, val1, test2, val2, elseval)
 ```
 
 is the equivalent of the JavaScript statement
 
-```js
+```javascript
 if (test1) {
     return val1;
 } else if (test2) {
@@ -45,7 +45,7 @@ if (test1) {
 
 __Example:__ Test the value of x.
 
-```js
+```javascript
 var x = 10;
 r.branch(r.expr(x).gt(5), 'big', 'small').run(conn, callback);
 // Result passed to callback
@@ -54,7 +54,7 @@ r.branch(r.expr(x).gt(5), 'big', 'small').run(conn, callback);
 
 __Example:__ As above, infix-style.
 
-```js
+```javascript
 var x = 10;
 r.expr(x).gt(5).branch('big', 'small').run(conn, callback);
 // Result passed to callback
@@ -63,7 +63,7 @@ r.expr(x).gt(5).branch('big', 'small').run(conn, callback);
 
 __Example:__ Categorize heroes by victory counts.
 
-```js
+```javascript
 r.table('marvel').map(
     r.branch(
         r.row('victories').gt(100),
@@ -77,7 +77,7 @@ r.table('marvel').map(
 
 If the documents in the table `marvel` are:
 
-```js
+```javascript
 [
     { name: "Iron Man", victories: 214 },
     { name: "Jubilee", victories: 49 },
@@ -87,7 +87,7 @@ If the documents in the table `marvel` are:
 
 The results will be:
 
-```js
+```javascript
 [
     "Iron Man is a superhero",
     "Jubilee is a hero",

--- a/api/javascript/control-structures/coerce_to.md
+++ b/api/javascript/control-structures/coerce_to.md
@@ -45,7 +45,7 @@ Convert a value of one type into another.
 
 __Example:__ Coerce a stream to an array to store its output in a field. (A stream cannot be stored in a field directly.)
 
-```js
+```javascript
 r.table('posts').map(function (post) {
     return post.merge({ comments: r.table('comments').getAll(post('id'), {index: 'postId'}).coerceTo('array')});
 }).run(conn, callback)
@@ -54,7 +54,7 @@ r.table('posts').map(function (post) {
 __Example:__ Coerce an array of key-value pairs into an object.
 
 
-```js
+```javascript
 r.expr([['name', 'Ironman'], ['victories', 2000]]).coerceTo('object').run(conn, callback)
 ```
 
@@ -62,6 +62,6 @@ __Note:__ To coerce a list of key-value pairs like `['name', 'Ironman', 'victori
 
 __Example:__ Coerce a number to a string.
 
-```js
+```javascript
 r.expr(1).coerceTo('string').run(conn, callback)
 ```

--- a/api/javascript/control-structures/default.md
+++ b/api/javascript/control-structures/default.md
@@ -25,7 +25,7 @@ __Example:__ Retrieve the titles and authors of the table `posts`.
 In the case where the author field is missing or `null`, we want to retrieve the string
 `Anonymous`.
 
-```js
+```javascript
 r.table("posts").map(function (post) {
     return {
         title: post("title"),
@@ -38,7 +38,7 @@ r.table("posts").map(function (post) {
 
 We can rewrite the previous query with `r.branch` too.
 
-```js
+```javascript
 r.table("posts").map(function (post) {
     return r.branch(
         post.hasFields("author"),
@@ -57,7 +57,7 @@ r.table("posts").map(function (post) {
 __Example:__ The `default` command can also be used to filter documents. Retrieve all our users who are not grown-ups or whose age is unknown
 (i.e., the field `age` is missing or equals `null`).
 
-```js
+```javascript
 r.table("users").filter(function (user) {
     return user("age").lt(18).default(true)
 }).run(conn, callback);
@@ -66,7 +66,7 @@ r.table("users").filter(function (user) {
 One more way to write the previous query is to set the age to be `-1` when the
 field is missing.
 
-```js
+```javascript
 r.table("users").filter(function (user) {
     return user("age").default(-1).lt(18)
 }).run(conn, callback);
@@ -74,7 +74,7 @@ r.table("users").filter(function (user) {
 
 This can be accomplished with [hasFields](/api/javascript/has_fields/) rather than `default`.
 
-```js
+```javascript
 r.table("users").filter(function (user) {
     return user.hasFields("age").not().or(user("age").lt(18))
 }).run(conn, callback);
@@ -82,7 +82,7 @@ r.table("users").filter(function (user) {
 
 The body of every [filter](/api/javascript/filter/) is wrapped in an implicit `.default(false)`. You can overwrite the value `false` with the `default` option.
 
-```js
+```javascript
 r.table("users").filter(function (user) {
     return user("age").lt(18)
 }, {default: true} ).run(conn, callback);
@@ -90,7 +90,7 @@ r.table("users").filter(function (user) {
 
 __Example:__ The function form of `default` receives the error message as its argument.
 
-```js
+```javascript
 r.table("posts").map(function (post) {
     return {
         title: post("title"),

--- a/api/javascript/control-structures/do.md
+++ b/api/javascript/control-structures/do.md
@@ -29,7 +29,7 @@ Arguments passed to the `do` function must be basic data types, and cannot be st
 
 __Example:__ Compute a golfer's net score for a game.
 
-```js
+```javascript
 r.table('players').get('f19b5f16-ef14-468f-bd48-e194761df255').do(
     function (player) {
         return player('gross_score').sub(player('course_handicap'));
@@ -39,7 +39,7 @@ r.table('players').get('f19b5f16-ef14-468f-bd48-e194761df255').do(
 
 __Example:__ Return the best scoring player in a two-player golf match.
 
-```js
+```javascript
 r.do(r.table('players').get(id1), r.table('players').get(id2),
     function (player1, player2) {
         return r.branch(player1('gross_score').lt(player2('gross_score')),
@@ -52,7 +52,7 @@ Note that `branch`, the ReQL conditional command, must be used instead of `if`. 
 
 __Example:__ Take different actions based on the result of a ReQL [insert](/api/javascript/insert) command.
 
-```js
+```javascript
 var newData = {
     id: 100,
     name: 'Agatha',

--- a/api/javascript/control-structures/error.md
+++ b/api/javascript/control-structures/error.md
@@ -20,7 +20,7 @@ Throw a runtime error. If called with no arguments inside the second argument to
 
 __Example:__ Iron Man can't possibly have lost a battle:
 
-```js
+```javascript
 r.table('marvel').get('IronMan').do(function(ironman) {
     return r.branch(ironman('victories').lt(ironman('battles')),
         r.error('impossible code path'),

--- a/api/javascript/control-structures/expr.md
+++ b/api/javascript/control-structures/expr.md
@@ -22,14 +22,14 @@ If the native object is a Node.js `Buffer`, then `expr` will return a binary obj
 
 __Example:__ Objects wrapped with `expr` can then be manipulated by ReQL API functions.
 
-```js
+```javascript
 r.expr({a:'b'}).merge({b:[1,2,3]}).run(conn, callback)
 ```
 
 
 __Example:__ In JavaScript, you can also do this with just r.
 
-```js
+```javascript
 r({a: 'b'}).merge({b: [1,2,3]}).run(conn, callback)
 ```
 

--- a/api/javascript/control-structures/for_each.md
+++ b/api/javascript/control-structures/for_each.md
@@ -22,7 +22,7 @@ Loop over a sequence, evaluating the given write query for each element.
 
 __Example:__ Now that our heroes have defeated their villains, we can safely remove them from the villain table.
 
-```js
+```javascript
 r.table('marvel').forEach(function(hero) {
     return r.table('villains').get(hero('villainDefeated')).delete()
 }).run(conn, callback)

--- a/api/javascript/control-structures/http.md
+++ b/api/javascript/control-structures/http.md
@@ -23,7 +23,7 @@ Retrieve data from the specified URL over HTTP.  The return type depends on the 
 
 __Example:__ Perform an HTTP `GET` and store the result in a table.
 
-```js
+```javascript
 r.table('posts').insert(r.http('http://httpbin.org/get')).run(conn, callback)
 ```
 
@@ -65,7 +65,7 @@ See [the tutorial](/docs/external-api-access/) on `r.http` for more examples on 
 
 __Example:__ Perform multiple requests with different parameters.
 
-```js
+```javascript
 r.expr([1, 2, 3]).map(function(i) {
     return r.http('http://httpbin.org/get', { params: { user: i } });
 }).run(conn, callback)
@@ -73,7 +73,7 @@ r.expr([1, 2, 3]).map(function(i) {
 
 __Example:__ Perform a `PUT` request for each item in a table.
 
-```js
+```javascript
 r.table('data').map(function(row) {
     return r.http('http://httpbin.org/put', { method: 'PUT', data: row });
 }).run(conn, callback)
@@ -83,7 +83,7 @@ __Example:__ Perform a `POST` request with accompanying data.
 
 Using form-encoded data:
 
-```js
+```javascript
 r.http('http://httpbin.org/post',
        { method: 'POST', data: { player: 'Bob', game: 'tic tac toe' } })
 .run(conn, callback)
@@ -91,7 +91,7 @@ r.http('http://httpbin.org/post',
 
 Using JSON data:
 
-```js
+```javascript
 r.http('http://httpbin.org/post',
        { method: 'POST',
          data: r.expr(value).coerceTo('string'),
@@ -113,7 +113,7 @@ At the moment, the only built-in strategy is `'link-next'`, which is equivalent 
 
 __Example:__ Perform a GitHub search and collect up to 3 pages of results.
 
-```js
+```javascript
 r.http("https://api.github.com/search/code?q=addClass+user:mozilla",
        { page: 'link-next', pageLimit: 3 }
 ).run(conn, callback)
@@ -121,7 +121,7 @@ r.http("https://api.github.com/search/code?q=addClass+user:mozilla",
 
 As a function, `page` takes one parameter, an object of the format:
 
-```js
+```javascript
 {
     params: object // the URL parameters used in the last request
     header: object // the HTTP headers of the last response as key/value pairs
@@ -131,7 +131,7 @@ As a function, `page` takes one parameter, an object of the format:
 
 The `header` field will be a parsed version of the header with fields lowercased, like so:
 
-```js
+```javascript
 {
     'content-length': '1024',
     'content-type': 'application/json',
@@ -145,7 +145,7 @@ The `header` field will be a parsed version of the header with fields lowercased
 
 The `page` function may return a string corresponding to the next URL to request, `null` indicating that there is no more to get, or an object of the format:
 
-```js
+```javascript
 {
     url: string // the next URL to request, or null for no more pages
     params: object // new URL parameters to use, will be merged with the previous request's params
@@ -154,7 +154,7 @@ The `page` function may return a string corresponding to the next URL to request
 
 __Example:__ Perform depagination with a custom `page` function.
 
-```js
+```javascript
 r.http('example.com/pages',
        { page: function(info) { return info('body')('meta')('next').default(null); },
          pageLimit: 5 })

--- a/api/javascript/control-structures/info.md
+++ b/api/javascript/control-structures/info.md
@@ -21,6 +21,6 @@ Get information about a ReQL value.
 
 __Example:__ Get information about a table such as primary key, or cache size.
 
-```js
+```javascript
 r.table('marvel').info().run(conn, callback)
 ```

--- a/api/javascript/control-structures/js.md
+++ b/api/javascript/control-structures/js.md
@@ -26,13 +26,13 @@ Whenever possible, you should use native ReQL commands rather than `r.js` for be
 
 __Example:__ Concatenate two strings using JavaScript.
 
-```js
+```javascript
 r.js("'str1' + 'str2'").run(conn, callback)
 ```
 
 __Example:__ Select all documents where the 'magazines' field is greater than 5 by running JavaScript on the server.
 
-```js
+```javascript
 r.table('marvel').filter(
     r.js('(function (row) { return row.magazines.length > 5; })')
 ).run(conn, callback)
@@ -41,7 +41,7 @@ r.table('marvel').filter(
 
 __Example:__ You may also specify a timeout in seconds (defaults to 5).
 
-```js
+```javascript
 r.js('while(true) {}', {timeout:1.3}).run(conn, callback)
 ```
 

--- a/api/javascript/control-structures/json.md
+++ b/api/javascript/control-structures/json.md
@@ -20,6 +20,6 @@ Parse a JSON string on the server.
 
 __Example:__ Send an array to the server.
 
-```js
+```javascript
 r.json("[1,2,3]").run(conn, callback)
 ```

--- a/api/javascript/control-structures/range.md
+++ b/api/javascript/control-structures/range.md
@@ -30,7 +30,7 @@ Any specified arguments must be integers, or a `ReqlRuntimeError` will be thrown
 
 __Example:__ Return a four-element range of `[0, 1, 2, 3]`.
 
-```js
+```javascript
 > r.range(4).run(conn, callback)
 // result returned to callback
 [0, 1, 2, 3]
@@ -40,7 +40,7 @@ __Example:__ Return a four-element range of `[0, 1, 2, 3]`.
 
 You can also use the [limit](/api/javascript/limit) command with the no-argument variant to achieve the same result in this case:
 
-```js
+```javascript
 > r.range().limit(4).run(conn, callback)
 // result returned to callback
 [0, 1, 2, 3]
@@ -48,7 +48,7 @@ You can also use the [limit](/api/javascript/limit) command with the no-argument
 
 __Example:__ Return a range from -5 through 5.
 
-```js
+```javascript
 > r.range(-5, 6).run(conn, callback)
 // result returned to callback
 [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]

--- a/api/javascript/control-structures/to_json_string.md
+++ b/api/javascript/control-structures/to_json_string.md
@@ -22,7 +22,7 @@ Convert a ReQL value or object to a JSON string. You may use either `toJsonStrin
 
 __Example:__ Get a ReQL document as a JSON string.
 
-```js
+```javascript
 > r.table('hero').get(1).toJSON()
 // result returned to callback
 '{"id": 1, "name": "Batman", "city": "Gotham", "powers": ["martial arts", "cinematic entrances"]}'

--- a/api/javascript/control-structures/type_of.md
+++ b/api/javascript/control-structures/type_of.md
@@ -46,7 +46,7 @@ Read the article on [ReQL data types](/docs/data-types/) for a more detailed dis
 
 __Example:__ Get the type of a string.
 
-```js
+```javascript
 r.expr("foo").typeOf().run(conn, callback);
 // Result passed to callback
 "STRING"

--- a/api/javascript/control-structures/uuid.md
+++ b/api/javascript/control-structures/uuid.md
@@ -24,7 +24,7 @@ RethinkDB's UUIDs are standards-compliant. Without the optional argument, a vers
 
 __Example:__ Generate a UUID.
 
-```js
+```javascript
 > r.uuid().run(conn, callback)
 // result returned to callback
 "27961a0e-f4e8-4eb3-bf95-c5203e1d87b9"
@@ -32,7 +32,7 @@ __Example:__ Generate a UUID.
 
 __Example:__ Generate a UUID based on a string.
 
-```js
+```javascript
 > r.uuid("slava@example.com").run(conn, callback)
 // Result passed to callback
 "90691cbc-b5ea-5826-ae98-951e30fc3b2d"

--- a/api/javascript/cursors/close-cursor.md
+++ b/api/javascript/cursors/close-cursor.md
@@ -27,7 +27,7 @@ The `close` command can optionally take a callback, which will receive an error 
 
 __Example:__ Close a cursor.
 
-```js
+```javascript
 cursor.close(function (err) {
     if (err) {
         console.log("An error occurred on cursor close");
@@ -37,7 +37,7 @@ cursor.close(function (err) {
 
 __Example:__ Close a cursor and execute a function upon close.
 
-```js
+```javascript
 cursor.close()
     .then(function () {
         console.log("The cursor has been closed");

--- a/api/javascript/cursors/each.md
+++ b/api/javascript/cursors/each.md
@@ -28,7 +28,7 @@ returns `false`).
 
 __Example:__ Let's process all the elements!
 
-```js
+```javascript
 cursor.each(function(err, row) {
     if (err) throw err;
     processRow(row);
@@ -37,7 +37,7 @@ cursor.each(function(err, row) {
 
 __Example:__ If we need to know when the iteration is complete, `each` also accepts a second `onFinished` callback.
 
-```js
+```javascript
 cursor.each(function(err, row) {
         if (err) throw err;
         processRow(row);
@@ -51,7 +51,7 @@ cursor.each(function(err, row) {
 __Example:__ Iteration can be stopped prematurely by returning `false` from the callback.
 For instance, if you want to stop the iteration as soon as `row` is negative:
 
-```js
+```javascript
 cursor.each(function(err, row) {
     if (err) throw err;
 

--- a/api/javascript/cursors/each_async.md
+++ b/api/javascript/cursors/each_async.md
@@ -22,13 +22,13 @@ Lazily iterate over a cursor, array, or feed one element at a time. `eachAsync` 
 
 The first, required function passed to `eachAsync` takes either one or two functions as arguments. The first is a callback to process each row as it is emitted; the second is an optional callback which will be executed when all row processing is completed.
 
-```js
+```javascript
 function(rowProcess[, final])
 ```
 
 The `rowProcess` callback receives the row as its first argument; it may also take an optional second argument, which is a callback function to be executed after each row has been processed.
 
-```js
+```javascript
 function(row[, rowFinished])
 ```
 
@@ -40,7 +40,7 @@ If you provide a `final` callback, it will always be executed when row processin
 
 To summarize all of the above in code:
 
-```js
+```javascript
 // process each row asynchronously
 cursor.eachAsync(function (row) {
     doSomethingWith(row);
@@ -64,7 +64,7 @@ cursor.eachAsync(function (row, rowFinished) {
 
 __Example:__ Process all the elements in a stream, using `then` and `catch` for handling the end of the stream and any errors. Note that iteration may be stopped in the first callback (`rowProcess`) by returning any non-Promise value.
 
-```js
+```javascript
 cursor.eachAsync(function (row) {
     var ok = processRowData(row);
     if (!ok) {
@@ -79,7 +79,7 @@ cursor.eachAsync(function (row) {
 
 __Example:__ As above, but using the `rowFinished` and `final` callbacks rather than the Promise returned from `eachAsync`.
 
-```js
+```javascript
 cursor.eachAsync(
     function (row, rowFinished) {
         var ok = processRowData(row);

--- a/api/javascript/cursors/ee-cursor.md
+++ b/api/javascript/cursors/ee-cursor.md
@@ -45,7 +45,7 @@ Cursors and feeds implement the same interface as Node's [EventEmitter](http://n
 
 __Example:__ Broadcast all messages with [socket.io](http://socket.io).
 
-```js
+```javascript
 r.table("messages").orderBy({index: "date"}).run(conn, function(err, cursor) {
     if (err) {
         // Handle error
@@ -65,7 +65,7 @@ r.table("messages").orderBy({index: "date"}).run(conn, function(err, cursor) {
 
 This query can be rewritten with the `each` command:
 
-```js
+```javascript
 r.table("messages").orderBy({index: "date"}).run(conn, function(err, cursor) {
     if (err) {
         // Handle error
@@ -84,7 +84,7 @@ r.table("messages").orderBy({index: "date"}).run(conn, function(err, cursor) {
 
 __Example:__ Broadcast all the messages inserted.
 
-```js
+```javascript
 r.table("messages").changes().filter({old_val: null}).run(conn, function(err, feed) {
     if (err) {
         // Handle error

--- a/api/javascript/cursors/next.md
+++ b/api/javascript/cursors/next.md
@@ -29,7 +29,7 @@ Calling `next` the first time on a cursor provides the first element of the curs
 
 __Example:__ Retrieve the next element.
 
-```js
+```javascript
 cursor.next(function(err, row) {
     if (err) throw err;
     processRow(row);
@@ -43,7 +43,7 @@ __Note:__ The canonical way to retrieve all the results is to use [each](../each
 __Example:__ You can retrieve all the elements of a cursor with the `next`
 command using recursion.
 
-```js
+```javascript
 query.run( conn, function(err, cursor) {
     if (err) throw err;
 
@@ -71,7 +71,7 @@ __Example:__ With `next`, not all results have to be retrieved from a cursor
 -- to stop retrieving results, break out of the recursive function. For example, this
 recursive function will stop retrieving results when the `checkRow` function returns true:
 
-```js
+```javascript
 query.run( conn, function(err, cursor) {
     if (err) throw err;
 
@@ -104,7 +104,7 @@ query.run( conn, function(err, cursor) {
 __Example:__ You can retrieve all the elements of a cursor with the `next`
 command using recursion and promises.
 
-```js
+```javascript
 query.run(conn).then(function(cursor) {
     var errorHandler = function(err) {
         if (((err.name === "ReqlDriverError") && err.message === "No more rows in the cursor.")) {

--- a/api/javascript/cursors/to_array.md
+++ b/api/javascript/cursors/to_array.md
@@ -32,7 +32,7 @@ information on feeds.
 __Example:__ For small result sets it may be more convenient to process them at once as
 an array.
 
-```js
+```javascript
 cursor.toArray(function(err, results) {
     if (err) throw err;
     processResults(results);
@@ -43,7 +43,7 @@ cursor.toArray(function(err, results) {
 
 The equivalent query with the `each` command would be:
 
-```js
+```javascript
 var results = []
 cursor.each(function(err, row) {
     if (err) throw err;
@@ -56,7 +56,7 @@ cursor.each(function(err, row) {
 
 An equivalent query using promises.
 
-```js
+```javascript
 cursor.toArray().then(function(results) {
     processResults(results);
 }).error(console.log);

--- a/api/javascript/dates-and-times/date.md
+++ b/api/javascript/dates-and-times/date.md
@@ -24,7 +24,7 @@ Return a new time object only based on the day, month and year (ie. the same day
 
 __Example:__ Retrieve all the users whose birthday is today.
 
-```js
+```javascript
 r.table("users").filter(function(user) {
     return user("birthdate").date().eq(r.now().date())
 }).run(conn, callback)
@@ -34,7 +34,7 @@ r.table("users").filter(function(user) {
 
 Note that the [now][] command always returns UTC time, so the comparison may fail if `user("birthdate")` isn't also in UTC. You can use the [inTimezone][itz] command to adjust for this:
 
-```js
+```javascript
 r.table("users").filter(function(user) {
     return user("birthdate").date().eq(r.now().inTimezone("-08:00").date())
 }).run(conn, callback)

--- a/api/javascript/dates-and-times/day.md
+++ b/api/javascript/dates-and-times/day.md
@@ -23,7 +23,7 @@ Return the day of a time object as a number between 1 and 31.
 
 __Example:__ Return the users born on the 24th of any month.
 
-```js
+```javascript
 r.table("users").filter(
     r.row("birthdate").day().eq(24)
 ).run(conn, callback)

--- a/api/javascript/dates-and-times/day_of_week.md
+++ b/api/javascript/dates-and-times/day_of_week.md
@@ -23,13 +23,13 @@ Return the day of week of a time object as a number between 1 and 7 (following I
 
 __Example:__ Return today's day of week.
 
-```js
+```javascript
 r.now().dayOfWeek().run(conn, callback)
 ```
 
 __Example:__ Retrieve all the users who were born on a Tuesday.
 
-```js
+```javascript
 r.table("users").filter(
     r.row("birthdate").dayOfWeek().eq(r.tuesday)
 )

--- a/api/javascript/dates-and-times/day_of_year.md
+++ b/api/javascript/dates-and-times/day_of_year.md
@@ -23,7 +23,7 @@ Return the day of the year of a time object as a number between 1 and 366 (follo
 
 __Example:__ Retrieve all the users who were born the first day of a year.
 
-```js
+```javascript
 r.table("users").filter(
     r.row("birthdate").dayOfYear().eq(1)
 )

--- a/api/javascript/dates-and-times/during.md
+++ b/api/javascript/dates-and-times/during.md
@@ -27,7 +27,7 @@ By default, this is inclusive of the start time and exclusive of the end time. S
 __Example:__ Retrieve all the posts that were posted between December 1st, 2013
 (inclusive) and December 10th, 2013 (exclusive).
 
-```js
+```javascript
 r.table("posts").filter(
     r.row('date').during(r.time(2013, 12, 1, "Z"), r.time(2013, 12, 10, "Z"))
 ).run(conn, callback)
@@ -37,7 +37,7 @@ r.table("posts").filter(
 __Example:__ Retrieve all the posts that were posted between December 1st, 2013
 (exclusive) and December 10th, 2013 (inclusive).
 
-```js
+```javascript
 r.table("posts").filter(
   r.row('date').during(r.time(2013, 12, 1, "Z"), r.time(2013, 12, 10, "Z"), {leftBound: "open", rightBound: "closed"})
 ).run(conn, callback)

--- a/api/javascript/dates-and-times/epoch_time.md
+++ b/api/javascript/dates-and-times/epoch_time.md
@@ -25,6 +25,6 @@ will be rounded to three decimal places (millisecond-precision).
 
 __Example:__ Update the birthdate of the user "John" to November 3rd, 1986.
 
-```js
+```javascript
 r.table("user").get("John").update({birthdate: r.epochTime(531360000)}).run(conn, callback)
 ```

--- a/api/javascript/dates-and-times/hours.md
+++ b/api/javascript/dates-and-times/hours.md
@@ -23,7 +23,7 @@ Return the hour in a time object as a number between 0 and 23.
 
 __Example:__ Return all the posts submitted after midnight and before 4am.
 
-```js
+```javascript
 r.table("posts").filter(function(post) {
     return post("date").hours().lt(4)
 })

--- a/api/javascript/dates-and-times/in_timezone.md
+++ b/api/javascript/dates-and-times/in_timezone.md
@@ -24,7 +24,7 @@ Return a new time object with a different timezone. While the time stays the sam
 
 __Example:__ Hour of the day in San Francisco (UTC/GMT -8, without daylight saving time).
 
-```js
+```javascript
 r.now().inTimezone('-08:00').hours().run(conn, callback)
 ```
 

--- a/api/javascript/dates-and-times/iso8601.md
+++ b/api/javascript/dates-and-times/iso8601.md
@@ -26,7 +26,7 @@ If you pass an ISO 8601 string without a time zone, you must specify the time zo
 
 __Example:__ Update the time of John's birth.
 
-```js
+```javascript
 r.table("user").get("John").update({birth: r.ISO8601('1986-11-03T08:30:00-07:00')}).run(conn, callback)
 ```
 

--- a/api/javascript/dates-and-times/minutes.md
+++ b/api/javascript/dates-and-times/minutes.md
@@ -23,7 +23,7 @@ Return the minute in a time object as a number between 0 and 59.
 
 __Example:__ Return all the posts submitted during the first 10 minutes of every hour.
 
-```js
+```javascript
 r.table("posts").filter(function(post) {
     return post("date").minutes().lt(10)
 })

--- a/api/javascript/dates-and-times/month.md
+++ b/api/javascript/dates-and-times/month.md
@@ -24,7 +24,7 @@ Return the month of a time object as a number between 1 and 12. For your conveni
 
 __Example:__ Retrieve all the users who were born in November.
 
-```js
+```javascript
 r.table("users").filter(
     r.row("birthdate").month().eq(11)
 )
@@ -33,7 +33,7 @@ r.table("users").filter(
 
 __Example:__ Retrieve all the users who were born in November.
 
-```js
+```javascript
 r.table("users").filter(
     r.row("birthdate").month().eq(r.november)
 )

--- a/api/javascript/dates-and-times/now.md
+++ b/api/javascript/dates-and-times/now.md
@@ -24,7 +24,7 @@ Return a time object representing the current time in UTC. The command now() is 
 
 __Example:__ Add a new user with the time at which he subscribed.
 
-```js
+```javascript
 r.table("users").insert({
     name: "John",
     subscription_date: r.now()

--- a/api/javascript/dates-and-times/seconds.md
+++ b/api/javascript/dates-and-times/seconds.md
@@ -23,7 +23,7 @@ Return the seconds in a time object as a number between 0 and 59.999 (double pre
 
 __Example:__ Return the post submitted during the first 30 seconds of every minute.
 
-```js
+```javascript
 r.table("posts").filter(function(post) {
     return post("date").seconds().lt(30)
 })

--- a/api/javascript/dates-and-times/time.md
+++ b/api/javascript/dates-and-times/time.md
@@ -37,6 +37,6 @@ A few restrictions exist on the arguments:
 
 __Example:__ Update the birthdate of the user "John" to November 3rd, 1986 UTC.
 
-```js
+```javascript
 r.table("user").get("John").update({birthdate: r.time(1986, 11, 3, 'Z')}).run(conn, callback)
 ```

--- a/api/javascript/dates-and-times/time_of_day.md
+++ b/api/javascript/dates-and-times/time_of_day.md
@@ -24,7 +24,7 @@ Return the number of seconds elapsed since the beginning of the day stored in th
 
 __Example:__ Retrieve posts that were submitted before noon.
 
-```js
+```javascript
 r.table("posts").filter(
     r.row("date").timeOfDay().le(12*60*60)
 ).run(conn, callback)

--- a/api/javascript/dates-and-times/timezone.md
+++ b/api/javascript/dates-and-times/timezone.md
@@ -24,7 +24,7 @@ Return the timezone of the time object.
 
 __Example:__ Return all the users in the "-07:00" timezone.
 
-```js
+```javascript
 r.table("users").filter( function(user) {
     return user("subscriptionDate").timezone().eq("-07:00")
 })

--- a/api/javascript/dates-and-times/to_epoch_time.md
+++ b/api/javascript/dates-and-times/to_epoch_time.md
@@ -23,7 +23,7 @@ Convert a time object to its epoch time.
 
 __Example:__ Return the current time in seconds since the Unix Epoch with millisecond-precision.
 
-```js
+```javascript
 r.now().toEpochTime()
 ```
 

--- a/api/javascript/dates-and-times/to_iso8601.md
+++ b/api/javascript/dates-and-times/to_iso8601.md
@@ -23,7 +23,7 @@ Convert a time object to a string in ISO 8601 format.
 
 __Example:__ Return the current ISO 8601 time.
 
-```js
+```javascript
 r.now().toISO8601().run(conn, callback)
 // Result passed to callback
 "2015-04-20T18:37:52.690+00:00"

--- a/api/javascript/dates-and-times/year.md
+++ b/api/javascript/dates-and-times/year.md
@@ -23,7 +23,7 @@ Return the year of a time object.
 
 __Example:__ Retrieve all the users born in 1986.
 
-```js
+```javascript
 r.table("users").filter(function(user) {
     return user("birthdate").year().eq(1986)
 }).run(conn, callback)

--- a/api/javascript/document-manipulation/append.md
+++ b/api/javascript/document-manipulation/append.md
@@ -24,7 +24,7 @@ Append a value to an array.
 
 __Example:__ Retrieve Iron Man's equipment list with the addition of some new boots.
 
-```js
+```javascript
 r.table('marvel').get('IronMan')('equipment').append('newBoots').run(conn, callback)
 ```
 

--- a/api/javascript/document-manipulation/bracket.md
+++ b/api/javascript/document-manipulation/bracket.md
@@ -31,7 +31,7 @@ Get a single field from an object. If called on a sequence, gets that field from
 
 __Example:__ What was Iron Man's first appearance in a comic?
 
-```js
+```javascript
 r.table('marvel').get('IronMan')('firstAppearance').run(conn, callback)
 ```
 
@@ -41,7 +41,7 @@ The `()` command also accepts integer arguments as array offsets, like the [nth]
 
 __Example:__ Get the fourth element in a sequence. (The first element is position `0`, so the fourth element is position `3`.)
 
-```js
+```javascript
 r.expr([10, 20, 30, 40, 50])(3)
 
 40

--- a/api/javascript/document-manipulation/change_at.md
+++ b/api/javascript/document-manipulation/change_at.md
@@ -24,6 +24,6 @@ Change a value in an array at a given index. Returns the modified array.
 
 __Example:__ Bruce Banner hulks out.
 
-```js
+```javascript
 r.expr(["Iron Man", "Bruce", "Spider-Man"]).changeAt(1, "Hulk").run(conn, callback)
 ```

--- a/api/javascript/document-manipulation/delete_at.md
+++ b/api/javascript/document-manipulation/delete_at.md
@@ -30,7 +30,7 @@ By using a negative `offset` you can delete from the end of the array. `-1` is t
 
 __Example:__ Delete the second element of an array.
 
-```js
+```javascript
 > r(['a','b','c','d','e','f']).deleteAt(1).run(conn, callback)
 // result passed to callback
 ['a', 'c', 'd', 'e', 'f']
@@ -38,7 +38,7 @@ __Example:__ Delete the second element of an array.
 
 __Example:__ Delete the second and third elements of an array.
 
-```js
+```javascript
 > r(['a','b','c','d','e','f']).deleteAt(1,3).run(conn, callback)
 // result passed to callback
 ['a', 'd', 'e', 'f']
@@ -46,7 +46,7 @@ __Example:__ Delete the second and third elements of an array.
 
 __Example:__ Delete the next-to-last element of an array.
 
-```js
+```javascript
 > r(['a','b','c','d','e','f']).deleteAt(-2).run(conn, callback)
 // result passed to callback
 ['a', 'b', 'c', 'd', 'f']
@@ -56,7 +56,7 @@ __Example:__ Delete a comment on a post.
 
 Given a post document such as:
 
-```js
+```javascript
 {
     id: '4cf47834-b6f9-438f-9dec-74087e84eb63',
     title: 'Post title',
@@ -70,7 +70,7 @@ Given a post document such as:
 
 The second comment can be deleted by using `update` and `deleteAt` together.
 
-```js
+```javascript
 r.table('posts').get('4cf47834-b6f9-438f-9dec-74087e84eb63').update({
     comments: r.row('comments').deleteAt(1)
 }).run(conn, callback)

--- a/api/javascript/document-manipulation/difference.md
+++ b/api/javascript/document-manipulation/difference.md
@@ -25,7 +25,7 @@ Remove the elements of one array from another array.
 
 __Example:__ Retrieve Iron Man's equipment list without boots.
 
-```js
+```javascript
 r.table('marvel').get('IronMan')('equipment')
   .difference(['Boots'])
   .run(conn, callback)
@@ -33,7 +33,7 @@ r.table('marvel').get('IronMan')('equipment')
 
 __Example:__ Remove Iron Man's boots from his equipment.
 
-```js
+```javascript
 r.table('marvel').get('IronMan')
   .update({
     equipment: r.row('equipment').difference(['Boots'])

--- a/api/javascript/document-manipulation/get_field.md
+++ b/api/javascript/document-manipulation/get_field.md
@@ -30,6 +30,6 @@ object in the sequence, skipping objects that lack it.
 
 __Example:__ What was Iron Man's first appearance in a comic?
 
-```js
+```javascript
 r.table('marvel').get('IronMan').getField('firstAppearance').run(conn, callback)
 ```

--- a/api/javascript/document-manipulation/has_fields.md
+++ b/api/javascript/document-manipulation/has_fields.md
@@ -33,13 +33,13 @@ When applied to a single object, `hasFields` returns `true` if the object has th
 
 __Example:__ Return the players who have won games.
 
-```js
+```javascript
 r.table('players').hasFields('games_won').run(conn, callback)
 ```
 
 __Example:__ Return the players who have *not* won games. To do this, use `hasFields` with [not](/api/javascript/not), wrapped with [filter](/api/javascript/filter).
 
-```js
+```javascript
 r.table('players').filter(
     r.row.hasFields('games_won').not()
 ).run(conn, callback)
@@ -47,7 +47,7 @@ r.table('players').filter(
 
 __Example:__ Test if a specific player has won any games.
 
-```js
+```javascript
 r.table('players').get('b5ec9714-837e-400c-aa74-dbd35c9a7c4c'
     ).hasFields('games_won').run(conn, callback)
 ```
@@ -58,7 +58,7 @@ r.table('players').get('b5ec9714-837e-400c-aa74-dbd35c9a7c4c'
 
 __Example:__ In the `players` table, the `games_won` field contains one or more fields for kinds of games won:
 
-```js
+```javascript
 {
     games_won: {
         playoffs: 2,
@@ -69,13 +69,13 @@ __Example:__ In the `players` table, the `games_won` field contains one or more 
 
 Return players who have the "championships" field.
 
-```js
+```javascript
 r.table('players').hasFields({'games_won': {'championships': true}}).run(conn, callback)
 ```
 
 Note that `true` in the example above is testing for the existence of `championships` as a field, not testing to see if the value of the `championships` field is set to `true`. There's a more convenient shorthand form available. (See [pluck](/api/javascript/pluck) for more details on this.)
 
-```js
+```javascript
 r.table('players').hasFields({'games_won': 'championships'}
     ).run(conn, callback)
 ```

--- a/api/javascript/document-manipulation/insert_at.md
+++ b/api/javascript/document-manipulation/insert_at.md
@@ -24,7 +24,7 @@ Insert a value in to an array at a given index. Returns the modified array.
 
 __Example:__ Hulk decides to join the avengers.
 
-```js
+```javascript
 r.expr(["Iron Man", "Spider-Man"]).insertAt(1, "Hulk").run(conn, callback)
 ```
 

--- a/api/javascript/document-manipulation/keys.md
+++ b/api/javascript/document-manipulation/keys.md
@@ -25,7 +25,7 @@ Return an array containing all of an object's keys. Note that the keys will be s
 
 __Example:__ Get all the keys from a table row.
 
-```js
+```javascript
 // row: { id: 1, mail: "fred@example.com", name: "fred" }
 
 r.table('users').get(1).keys().run(conn, callback);

--- a/api/javascript/document-manipulation/literal.md
+++ b/api/javascript/document-manipulation/literal.md
@@ -22,7 +22,7 @@ Replace an object in a field instead of merging it with an existing object in a 
 
 Assume your users table has this structure:
 
-```js
+```javascript
 [
     {
         "id": 1,
@@ -38,7 +38,7 @@ Assume your users table has this structure:
 
 Using `update` to modify the `data` field will normally merge the nested documents:
 
-```js
+```javascript
 r.table('users').get(1).update({ data: { age: 19, job: 'Engineer' } }).run(conn, callback)
 
 // Result passed to callback
@@ -57,7 +57,7 @@ That will preserve `city` and other existing fields. But to replace the entire `
 
 __Example:__ Replace one nested document with another rather than merging the fields.
 
-```js
+```javascript
 r.table('users').get(1).update({ data: r.literal({ age: 19, job: 'Engineer' }) }).run(conn, callback)
 
 // Result passed to callback
@@ -73,7 +73,7 @@ r.table('users').get(1).update({ data: r.literal({ age: 19, job: 'Engineer' }) }
 
 __Example:__ Use `literal` to remove a field from a document.
 
-```js
+```javascript
 r.table('users').get(1).merge({ data: r.literal() }).run(conn, callback)
 
 // Result passed to callback

--- a/api/javascript/document-manipulation/merge.md
+++ b/api/javascript/document-manipulation/merge.md
@@ -33,7 +33,7 @@ Merge two or more objects together to construct a new object with properties fro
 
 __Example:__ Equip Thor for battle.
 
-```js
+```javascript
 r.table('marvel').get('thor').merge(
     r.table('equipment').get('hammer'),
     r.table('equipment').get('pimento_sandwich')
@@ -42,7 +42,7 @@ r.table('marvel').get('thor').merge(
 
 __Example:__ Equip every hero for battle, using a subquery function to retrieve their weapons.
 
-```js
+```javascript
 r.table('marvel').merge(function (hero) {
     return { weapons: r.table('weapons').get(hero('weaponId')) };
 }).run(conn, callback)
@@ -52,7 +52,7 @@ __Example:__ Use `merge` to join each blog post with its comments.
 
 Note that the sequence being merged&mdash;in this example, the comments&mdash;must be coerced from a selection to an array. Without `coerceTo` the operation will throw an error ("Expected type DATUM but found SELECTION").
 
-```js
+```javascript
 r.table('posts').merge(function (post) {
     return {
         comments: r.table('comments').getAll(post('id'),
@@ -63,7 +63,7 @@ r.table('posts').merge(function (post) {
 
 __Example:__ Merge can be used recursively to modify object within objects.
 
-```js
+```javascript
 r.expr({weapons : {spectacular_graviton_beam : {dmg : 10, cooldown : 20}}}).merge(
     {weapons : {spectacular_graviton_beam : {dmg : 10}}}).run(conn, callback)
 ```
@@ -71,7 +71,7 @@ r.expr({weapons : {spectacular_graviton_beam : {dmg : 10, cooldown : 20}}}).merg
 
 __Example:__ To replace a nested object with another object you can use the literal keyword.
 
-```js
+```javascript
 r.expr({weapons : {spectacular_graviton_beam : {dmg : 10, cooldown : 20}}}).merge(
     {weapons : r.literal({repulsor_rays : {dmg : 3, cooldown : 0}})}).run(conn, callback)
 ```
@@ -79,7 +79,7 @@ r.expr({weapons : {spectacular_graviton_beam : {dmg : 10, cooldown : 20}}}).merg
 
 __Example:__ Literal can be used to remove keys from an object as well.
 
-```js
+```javascript
 r.expr({weapons : {spectacular_graviton_beam : {dmg : 10, cooldown : 20}}}).merge(
     {weapons : {spectacular_graviton_beam : r.literal()}}).run(conn, callback)
 ```

--- a/api/javascript/document-manipulation/object.md
+++ b/api/javascript/document-manipulation/object.md
@@ -26,12 +26,12 @@ be strings.  `r.object(A, B, C, D)` is equivalent to
 
 __Example:__ Create a simple object.
 
-```js
+```javascript
 r.object('id', 5, 'data', ['foo', 'bar']).run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 {data: ["foo", "bar"], id: 5}
 ```

--- a/api/javascript/document-manipulation/pluck.md
+++ b/api/javascript/document-manipulation/pluck.md
@@ -36,28 +36,28 @@ Plucks out one or more attributes from either an object or a sequence of objects
 __Example:__ We just need information about IronMan's reactor and not the rest of the
 document.
 
-```js
+```javascript
 r.table('marvel').get('IronMan').pluck('reactorState', 'reactorPower').run(conn, callback)
 ```
 
 
 __Example:__ For the hero beauty contest we only care about certain qualities.
 
-```js
+```javascript
 r.table('marvel').pluck('beauty', 'muscleTone', 'charm').run(conn, callback)
 ```
 
 
 __Example:__ Pluck can also be used on nested objects.
 
-```js
+```javascript
 r.table('marvel').pluck({'abilities' : {'damage' : true, 'mana_cost' : true}, 'weapons' : true}).run(conn, callback)
 ```
 
 
 __Example:__ The nested syntax can quickly become overly verbose so there's a shorthand for it.
 
-```js
+```javascript
 r.table('marvel').pluck({'abilities' : ['damage', 'mana_cost']}, 'weapons').run(conn, callback)
 ```
 

--- a/api/javascript/document-manipulation/prepend.md
+++ b/api/javascript/document-manipulation/prepend.md
@@ -25,7 +25,7 @@ Prepend a value to an array.
 
 __Example:__ Retrieve Iron Man's equipment list with the addition of some new boots.
 
-```js
+```javascript
 r.table('marvel').get('IronMan')('equipment').prepend('newBoots').run(conn, callback)
 ```
 

--- a/api/javascript/document-manipulation/row.md
+++ b/api/javascript/document-manipulation/row.md
@@ -26,28 +26,28 @@ Note that `row` does not work within subqueries to access nested documents; you 
 
 __Example:__ Get all users whose age is greater than 5.
 
-```js
+```javascript
 r.table('users').filter(r.row('age').gt(5)).run(conn, callback)
 ```
 
 
 __Example:__ Access the attribute 'child' of an embedded document.
 
-```js
+```javascript
 r.table('users').filter(r.row('embedded_doc')('child').gt(5)).run(conn, callback)
 ```
 
 
 __Example:__ Add 1 to every element of an array.
 
-```js
+```javascript
 r.expr([1, 2, 3]).map(r.row.add(1)).run(conn, callback)
 ```
 
 
 __Example:__ For nested queries, use functions instead of `row`.
 
-```js
+```javascript
 r.table('users').filter(function(doc) {
     return doc('name').eq(r.table('prizes').get('winner'))
 }).run(conn, callback)

--- a/api/javascript/document-manipulation/set_difference.md
+++ b/api/javascript/document-manipulation/set_difference.md
@@ -26,7 +26,7 @@ distinct values).
 
 __Example:__ Check which pieces of equipment Iron Man has, excluding a fixed list.
 
-```js
+```javascript
 r.table('marvel').get('IronMan')('equipment').setDifference(['newBoots', 'arc_reactor']).run(conn, callback)
 ```
 

--- a/api/javascript/document-manipulation/set_insert.md
+++ b/api/javascript/document-manipulation/set_insert.md
@@ -25,7 +25,7 @@ Add a value to an array and return it as a set (an array with distinct values).
 
 __Example:__ Retrieve Iron Man's equipment list with the addition of some new boots.
 
-```js
+```javascript
 r.table('marvel').get('IronMan')('equipment').setInsert('newBoots').run(conn, callback)
 ```
 

--- a/api/javascript/document-manipulation/set_intersection.md
+++ b/api/javascript/document-manipulation/set_intersection.md
@@ -26,7 +26,7 @@ distinct values).
 
 __Example:__ Check which pieces of equipment Iron Man has from a fixed list.
 
-```js
+```javascript
 r.table('marvel').get('IronMan')('equipment').setIntersection(['newBoots', 'arc_reactor']).run(conn, callback)
 ```
 

--- a/api/javascript/document-manipulation/set_union.md
+++ b/api/javascript/document-manipulation/set_union.md
@@ -25,7 +25,7 @@ Add a several values to an array and return it as a set (an array with distinct 
 
 __Example:__ Retrieve Iron Man's equipment list with the addition of some new boots and an arc reactor.
 
-```js
+```javascript
 r.table('marvel').get('IronMan')('equipment').setUnion(['newBoots', 'arc_reactor']).run(conn, callback)
 ```
 

--- a/api/javascript/document-manipulation/splice_at.md
+++ b/api/javascript/document-manipulation/splice_at.md
@@ -24,7 +24,7 @@ Insert several values in to an array at a given index. Returns the modified arra
 
 __Example:__ Hulk and Thor decide to join the avengers.
 
-```js
+```javascript
 r.expr(["Iron Man", "Spider-Man"]).spliceAt(1, ["Hulk", "Thor"]).run(conn, callback)
 ```
 

--- a/api/javascript/document-manipulation/values.md
+++ b/api/javascript/document-manipulation/values.md
@@ -25,7 +25,7 @@ Return an array containing all of an object's values. `values()` guarantees the 
 
 __Example:__ Get all of the values from a table row.
 
-```js
+```javascript
 // row: { id: 1, mail: "fred@example.com", name: "fred" }
 
 r.table('users').get(1).values().run(conn, callback);

--- a/api/javascript/document-manipulation/without.md
+++ b/api/javascript/document-manipulation/without.md
@@ -34,28 +34,28 @@ the specified paths removed.
 __Example:__ Since we don't need it for this computation we'll save bandwidth and leave
 out the list of IronMan's romantic conquests.
 
-```js
+```javascript
 r.table('marvel').get('IronMan').without('personalVictoriesList').run(conn, callback)
 ```
 
 
 __Example:__ Without their prized weapons, our enemies will quickly be vanquished.
 
-```js
+```javascript
 r.table('enemies').without('weapons').run(conn, callback)
 ```
 
 
 __Example:__ Nested objects can be used to remove the damage subfield from the weapons and abilities fields.
 
-```js
+```javascript
 r.table('marvel').without({'weapons' : {'damage' : true}, 'abilities' : {'damage' : true}}).run(conn, callback)
 ```
 
 
 __Example:__ The nested syntax can quickly become overly verbose so there's a shorthand for it.
 
-```js
+```javascript
 r.table('marvel').without({'weapons':'damage', 'abilities':'damage'}).run(conn, callback)
 ```
 

--- a/api/javascript/geospatial/circle.md
+++ b/api/javascript/geospatial/circle.md
@@ -36,7 +36,7 @@ Optional arguments available with `circle` are:
 
 __Example:__ Define a circle.
 
-```js
+```javascript
 r.table('geo').insert({
     id: 300,
     name: 'Hayes Valley',

--- a/api/javascript/geospatial/distance.md
+++ b/api/javascript/geospatial/distance.md
@@ -31,7 +31,7 @@ If one of the objects is a polygon or a line, the point will be projected onto t
 
 __Example:__ Compute the distance between two points on the Earth in kilometers.
 
-```js
+```javascript
 var point1 = r.point(-122.423246,37.779388);
 var point2 = r.point(-117.220406,32.719464);
 r.distance(point1, point2, {unit: 'km'}).run(conn, callback);

--- a/api/javascript/geospatial/fill.md
+++ b/api/javascript/geospatial/fill.md
@@ -27,7 +27,7 @@ If the last point does not specify the same coordinates as the first point, `pol
 
 __Example:__ Create a line object and then convert it to a polygon.
 
-```js
+```javascript
 r.table('geo').insert({
     id: 201,
     rectangle: r.line(

--- a/api/javascript/geospatial/geojson.md
+++ b/api/javascript/geospatial/geojson.md
@@ -25,7 +25,7 @@ Only longitude/latitude coordinates are supported. GeoJSON objects that use Cart
 
 __Example:__ Convert a GeoJSON object to a ReQL geometry object.
 
-```js
+```javascript
 var geoJson = {
     'type': 'Point',
     'coordinates': [ -122.423246, 37.779388 ]

--- a/api/javascript/geospatial/get_intersecting.md
+++ b/api/javascript/geospatial/get_intersecting.md
@@ -24,7 +24,7 @@ The `index` argument is mandatory. This command returns the same results as `tab
 
 __Example:__ Which of the locations in a list of parks intersect `circle1`?
 
-```js
+```javascript
 var circle1 = r.circle([-117.220406,32.719464], 10, {unit: 'mi'});
 r.table('parks').getIntersecting(circle1, {index: 'area'}).run(conn, callback);
 ```

--- a/api/javascript/geospatial/get_nearest.md
+++ b/api/javascript/geospatial/get_nearest.md
@@ -31,7 +31,7 @@ The return value will be an array of two-item objects with the keys `dist` and `
 
 __Example:__ Return a list of the closest 25 enemy hideouts to the secret base.
 
-```js
+```javascript
 var secretBase = r.point(-122.422876,37.777128);
 r.table('hideouts').getNearest(secretBase,
     {index: 'location', maxResults: 25}

--- a/api/javascript/geospatial/includes.md
+++ b/api/javascript/geospatial/includes.md
@@ -25,7 +25,7 @@ Tests whether a geometry object is completely contained within another. When app
 
 __Example:__ Is `point2` included within a 2000-meter circle around `point1`?
 
-```js
+```javascript
 var point1 = r.point(-117.220406,32.719464);
 var point2 = r.point(-117.206201,32.725186);
 r.circle(point1, 2000).includes(point2).run(conn, callback);
@@ -35,7 +35,7 @@ true
 
 __Example:__ Which of the locations in a list of parks include `circle1`?
 
-```js
+```javascript
 var circle1 = r.circle([-117.220406,32.719464], 10, {unit: 'mi'});
 r.table('parks')('area').includes(circle1).run(conn, callback);
 ```
@@ -46,7 +46,7 @@ The `includes` command cannot take advantage of a geospatial [secondary index](/
 
 __Example:__ Rewrite the previous example with `getIntersecting`.
 
-```js
+```javascript
 var circle1 = r.circle([-117.220406,32.719464], 10, {unit: 'mi'});
 r.table('parks').getIntersecting(circle1, {index: 'area'})('area').
     includes(circle1).run(conn, callback);

--- a/api/javascript/geospatial/intersects.md
+++ b/api/javascript/geospatial/intersects.md
@@ -27,7 +27,7 @@ Tests whether two geometry objects intersect with one another. When applied to a
 
 __Example:__ Is `point2` within a 2000-meter circle around `point1`?
 
-```js
+```javascript
 var point1 = r.point(-117.220406,32.719464);
 var point2 = r.point(-117.206201,32.725186);
 r.circle(point1, 2000).intersects(point2).run(conn, callback);
@@ -37,7 +37,7 @@ true
 
 __Example:__ Which of the locations in a list of parks intersect `circle1`?
 
-```js
+```javascript
 var circle1 = r.circle([-117.220406,32.719464], 10, {unit: 'mi'});
 r.table('parks')('area').intersects(circle1).run(conn, callback);
 ```

--- a/api/javascript/geospatial/line.md
+++ b/api/javascript/geospatial/line.md
@@ -31,7 +31,7 @@ Longitude (&minus;180 to 180) and latitude (&minus;90 to 90) of vertices are plo
 
 __Example:__ Define a line.
 
-```js
+```javascript
 r.table('geo').insert({
     id: 101,
     route: r.line([-122.423246,37.779388], [-121.886420,37.329898])
@@ -42,7 +42,7 @@ __Example:__ Define a line using an array of points.
 
 You can use the [args](/api/javascript/args) command to pass an array of Point objects (or latitude-longitude pairs) to `line`.
 
-```js
+```javascript
 var route = [
     [-122.423246,37.779388],
     [-121.886420,37.329898]

--- a/api/javascript/geospatial/point.md
+++ b/api/javascript/geospatial/point.md
@@ -23,7 +23,7 @@ Construct a geometry object of type Point. The point is specified by two floatin
 
 __Example:__ Define a point.
 
-```js
+```javascript
 r.table('geo').insert({
     id: 1,
     name: 'San Francisco',

--- a/api/javascript/geospatial/polygon.md
+++ b/api/javascript/geospatial/polygon.md
@@ -34,7 +34,7 @@ If the last point does not specify the same coordinates as the first point, `pol
 
 __Example:__ Define a polygon.
 
-```js
+```javascript
 r.table('geo').insert({
     id: 101,
     rectangle: r.polygon(
@@ -50,7 +50,7 @@ __Example:__ Define a polygon using an array of vertices.
 
 You can use the [args](/api/javascript/args) command to pass an array of Point objects (or latitude-longitude pairs) to `polygon`.
 
-```js
+```javascript
 var vertices = [
     [-122.423246,37.779388],
     [-122.423246,37.329898],

--- a/api/javascript/geospatial/polygon_sub.md
+++ b/api/javascript/geospatial/polygon_sub.md
@@ -23,7 +23,7 @@ Use `polygon2` to "punch out" a hole in `polygon1`. `polygon2` must be completel
 
 __Example:__ Define a polygon with a hole punched in it.
 
-```js
+```javascript
 var outerPolygon = r.polygon(
     [-122.4,37.7],
     [-122.4,37.3],

--- a/api/javascript/geospatial/to_geojson.md
+++ b/api/javascript/geospatial/to_geojson.md
@@ -21,7 +21,7 @@ Convert a ReQL geometry object to a [GeoJSON](http://geojson.org) object.
 
 __Example:__ Convert a ReQL geometry object to a GeoJSON object.
 
-```js
+```javascript
 r.table('geo').get('sfo')('location').toGeojson.run(conn, callback);
 // result passed to callback
 {

--- a/api/javascript/index.md
+++ b/api/javascript/index.md
@@ -20,7 +20,7 @@ The top-level ReQL namespace.
 
 __Example:__ Set up your top-level namespace.
 
-```js
+```javascript
 var r = require('rethinkdb');
 ```
 
@@ -52,7 +52,7 @@ If the connection cannot be established, a `ReqlDriverError` will be passed to t
 
 __Example:__ Open a connection using the default host and port, specifying the default database.
 
-```js
+```javascript
 r.connect({
     db: 'marvel'
 }, function(err, conn) {
@@ -62,7 +62,7 @@ r.connect({
 
 If no callback is provided, a promise will be returned.
 
-```js
+```javascript
 var promise = r.connect({db: 'marvel'});
 ```
 
@@ -79,7 +79,7 @@ Close an open connection. If no callback is provided, a promise will be returned
 
 __Example:__ Close an open connection, waiting for noreply writes to finish.
 
-```js
+```javascript
 conn.close(function(err) { if (err) throw err; })
 ```
 
@@ -96,7 +96,7 @@ Close and reopen a connection. If no callback is provided, a promise will be ret
 
 __Example:__ Cancel outstanding requests/queries that are no longer needed.
 
-```js
+```javascript
 conn.reconnect({noreplyWait: false}, function(error, connection) { ... })
 ```
 
@@ -113,7 +113,7 @@ Change the default database on this connection.
 __Example:__ Change the default database so that we don't need to
 specify the database when referencing a table.
 
-```js
+```javascript
 conn.use('marvel')
 r.table('heroes').run(conn, ...) // refers to r.db('marvel').table('heroes')
 ```
@@ -133,7 +133,7 @@ result, or a cursor, depending on the query.
 __Example:__ Run a query on the connection `conn` and log each row in
 the result to the console.
 
-```js
+```javascript
 r.table('marvel').run(conn, function(err, cursor) {
     cursor.each(console.log);
 })
@@ -154,7 +154,7 @@ __Example:__ Subscribe to the changes on a table.
 
 Start monitoring the changefeed in one client:
 
-```js
+```javascript
 r.table('games').changes().run(conn, function(err, cursor) {
   cursor.each(console.log);
 });
@@ -163,7 +163,7 @@ r.table('games').changes().run(conn, function(err, cursor) {
 As these queries are performed in a second client, the first
 client would receive and print the following objects:
 
-```js
+```javascript
 > r.table('games').insert({id: 1}).run(conn, callback);
 {old_val: null, new_val: {id: 1}}
 
@@ -197,7 +197,7 @@ If no callback is provided, a promise will be returned.
 __Example:__ We have previously run queries with the `noreply` argument set to `true`. Now
 wait until the server has processed them.
 
-```js
+```javascript
 conn.noreplyWait(function(err) { ... })
 ```
 
@@ -214,7 +214,7 @@ Return information about the server being used by a connection.
 
 __Example:__ Return server information.
 
-```js
+```javascript
 conn.server(callback);
 
 // Result passed to callback
@@ -246,7 +246,7 @@ Connections implement the same interface as Node's [EventEmitter][ee]. This allo
 
 __Example:__ Monitor the connection state with events.
 
-```js
+```javascript
 r.connect({}, function(err, conn) {
     if (err) throw err;
 
@@ -281,7 +281,7 @@ Get the next element in the cursor.
 
 __Example:__ Retrieve the next element.
 
-```js
+```javascript
 cursor.next(function(err, row) {
     if (err) throw err;
     processRow(row);
@@ -304,7 +304,7 @@ returns `false`).
 
 __Example:__ Let's process all the elements!
 
-```js
+```javascript
 cursor.each(function(err, row) {
     if (err) throw err;
     processRow(row);
@@ -323,7 +323,7 @@ Lazily iterate over a cursor, array, or feed one element at a time. `eachAsync` 
 
 __Example:__ Process all the elements in a stream, using `then` and `catch` for handling the end of the stream and any errors. Note that iteration may be stopped in the first callback (`rowProcess`) by returning any non-Promise value.
 
-```js
+```javascript
 cursor.eachAsync(function (row) {
     var ok = processRowData(row);
     if (!ok) {
@@ -352,7 +352,7 @@ Retrieve all results and pass them as an array to the given callback.
 __Example:__ For small result sets it may be more convenient to process them at once as
 an array.
 
-```js
+```javascript
 cursor.toArray(function(err, results) {
     if (err) throw err;
     processResults(results);
@@ -372,7 +372,7 @@ Close a cursor. Closing a cursor cancels the corresponding query and frees the m
 
 __Example:__ Close a cursor.
 
-```js
+```javascript
 cursor.close(function (err) {
     if (err) {
         console.log("An error occurred on cursor close");
@@ -399,7 +399,7 @@ Cursors and feeds implement the same interface as Node's [EventEmitter](http://n
 
 __Example:__ Broadcast all messages with [socket.io](http://socket.io).
 
-```js
+```javascript
 r.table("messages").orderBy({index: "date"}).run(conn, function(err, cursor) {
     if (err) {
         // Handle error
@@ -432,7 +432,7 @@ relational databases.
 
 __Example:__ Create a database named 'superheroes'.
 
-```js
+```javascript
 > r.dbCreate('superheroes').run(conn, callback);
 // Result passed to callback
 {
@@ -461,7 +461,7 @@ Drop a database. The database, all its tables, and corresponding data will be de
 
 __Example:__ Drop a database named 'superheroes'.
 
-```js
+```javascript
 > r.dbDrop('superheroes').run(conn, callback);
 // Result passed to callback
 {
@@ -491,7 +491,7 @@ List all database names in the system. The result is a list of strings.
 
 __Example:__ List all databases.
 
-```js
+```javascript
 r.dbList().run(conn, callback)
 ```
 
@@ -512,7 +512,7 @@ Create a table. A RethinkDB table is a collection of JSON documents.
 
 __Example:__ Create a table named 'dc_universe' with the default settings.
 
-```js
+```javascript
 > r.db('heroes').tableCreate('dc_universe').run(conn, callback);
 // Result passed to callback
 {
@@ -554,7 +554,7 @@ Drop a table from a database. The table and all its data will be deleted.
 
 __Example:__ Drop a table named 'dc_universe'.
 
-```js
+```javascript
 > r.db('test').tableDrop('dc_universe').run(conn, callback);
 // Result passed to callback
 {
@@ -596,7 +596,7 @@ List all table names in a database. The result is a list of strings.
 
 __Example:__ List all tables of the 'test' database.
 
-```js
+```javascript
 r.db('test').tableList().run(conn, callback)
 ```
 
@@ -612,7 +612,7 @@ Create a new secondary index on a table. Secondary indexes improve the speed of 
 
 __Example:__ Create a simple index based on the field `postId`.
 
-```js
+```javascript
 r.table('comments').indexCreate('postId').run(conn, callback)
 ```
 
@@ -628,7 +628,7 @@ Delete a previously created secondary index of this table.
 
 __Example:__ Drop a secondary index named 'code_name'.
 
-```js
+```javascript
 r.table('dc').indexDrop('code_name').run(conn, callback)
 ```
 
@@ -644,7 +644,7 @@ List all the secondary indexes of this table.
 
 __Example:__ List the available secondary indexes for this table.
 
-```js
+```javascript
 r.table('marvel').indexList().run(conn, callback)
 ```
 
@@ -660,7 +660,7 @@ Rename an existing secondary index on a table. If the optional argument `overwri
 
 __Example:__ Rename an index on the comments table.
 
-```js
+```javascript
 r.table('comments').indexRename('postId', 'messageId').run(conn, callback)
 ```
 
@@ -677,7 +677,7 @@ of all indexes on this table if no indexes are specified.
 
 __Example:__ Get the status of all the indexes on `test`:
 
-```js
+```javascript
 r.table('test').indexStatus().run(conn, callback)
 ```
 
@@ -694,7 +694,7 @@ indexes on this table to be ready if no indexes are specified.
 
 __Example:__ Wait for all indexes on the table `test` to be ready:
 
-```js
+```javascript
 r.table('test').indexWait().run(conn, callback)
 ```
 
@@ -715,7 +715,7 @@ documents.
 
 __Example:__ Insert a document into the table `posts`.
 
-```js
+```javascript
 r.table("posts").insert({
     id: 1,
     title: "Lorem ipsum",
@@ -740,7 +740,7 @@ Update JSON documents in a table. Accepts a JSON document, a ReQL expression, or
 
 __Example:__ Update the status of the post with `id` of `1` to `published`.
 
-```js
+```javascript
 r.table("posts").get(1).update({status: "published"}).run(conn, callback)
 ```
 
@@ -763,7 +763,7 @@ have the same primary key as the original document.
 
 __Example:__ Replace the document with the primary key `1`.
 
-```js
+```javascript
 r.table("posts").get(1).replace({
     id: 1,
     title: "Lorem ipsum",
@@ -789,7 +789,7 @@ Delete one or more documents from a table.
 
 __Example:__ Delete a single document from the table `comments`.
 
-```js
+```javascript
 r.table("comments").get("7eab9e63-73f1-4f33-8ce4-95cbea626f59").delete().run(conn, callback)
 ```
 
@@ -809,7 +809,7 @@ until all previous writes to the table are persisted.
 __Example:__ After having updated multiple heroes with soft durability, we now want to wait
 until these changes are persisted.
 
-```js
+```javascript
 r.table('marvel').sync().run(conn, callback)
 ```
 
@@ -829,7 +829,7 @@ Reference a database.
 
 __Example:__ Explicitly specify a database for a query.
 
-```js
+```javascript
 r.db('heroes').table('marvel').run(conn, callback)
 ```
 
@@ -845,7 +845,7 @@ Return all documents in a table. Other commands may be chained after `table` to 
 
 __Example:__ Return all documents in the table 'marvel' of the default database.
 
-```js
+```javascript
 r.table('marvel').run(conn, callback)
 ```
 
@@ -861,7 +861,7 @@ Get a document by primary key.
 
 __Example:__ Find a document by UUID.
 
-```js
+```javascript
 r.table('posts').get('a9849eef-7176-4411-935b-79a6e3c56a74').run(conn, callback);
 ```
 
@@ -877,7 +877,7 @@ Get all documents where the given value matches the value of the requested index
 
 __Example:__ Secondary index keys are not guaranteed to be unique so we cannot query via [get](/api/javascript/get/) when using a secondary index.
 
-```js
+```javascript
 r.table('marvel').getAll('man_of_steel', {index:'code_name'}).run(conn, callback)
 ```
 
@@ -894,7 +894,7 @@ Get all documents between two keys. Accepts three optional arguments: `index`, `
 
 __Example:__ Find all users with primary key >= 10 and < 20 (a normal half-open interval).
 
-```js
+```javascript
 r.table('marvel').between(10, 20).run(conn, callback);
 ```
 
@@ -912,7 +912,7 @@ Return all the elements in a sequence for which the given predicate is true. The
 
 __Example:__ Get all users who are 30 years old.
 
-```js
+```javascript
 r.table('users').filter({age: 30}).run(conn, callback);
 ```
 
@@ -935,7 +935,7 @@ Returns an inner join of two sequences.
 
 __Example:__ Return a list of all matchups between Marvel and DC heroes in which the DC hero could beat the Marvel hero in a fight.
 
-```js
+```javascript
 r.table('marvel').innerJoin(r.table('dc'), function(marvelRow, dcRow) {
     return marvelRow('strength').lt(dcRow('strength'))
 }).zip().run(conn, callback)
@@ -954,7 +954,7 @@ Returns a left outer join of two sequences. The returned sequence represents a u
 
 __Example:__ Return a list of all Marvel heroes, paired with any DC heroes who could beat them in a fight.
 
-```js
+```javascript
 r.table('marvel').outerJoin(r.table('dc'), function(marvelRow, dcRow) {
     return marvelRow('strength').lt(dcRow('strength'))
 }).run(conn, callback)
@@ -977,13 +977,13 @@ __Example:__ Match players with the games they've played against one another.
 
 Join these tables using `gameId` on the player table and `id` on the games table:
 
-```js
+```javascript
 r.table('players').eqJoin('gameId', r.table('games')).run(conn, callback)
 ```
 
 This will return a result set such as the following:
 
-```js
+```javascript
 [
     {
         "left" : { "gameId" : 3, "id" : 2, "player" : "Agatha" },
@@ -1010,7 +1010,7 @@ Used to 'zip' up the result of a join by merging the 'right' fields into 'left' 
 
 __Example:__ 'zips up' the sequence by merging the left and right fields produced by a join.
 
-```js
+```javascript
 r.table('marvel').eqJoin('main_dc_collaborator', r.table('dc'))
     .zip().run(conn, callback)
 ```
@@ -1034,7 +1034,7 @@ Transform each element of one or more sequences by applying a mapping function t
 
 __Example:__ Return the first five squares.
 
-```js
+```javascript
 r.expr([1, 2, 3, 4, 5]).map(function (val) {
     return val.mul(val);
 }).run(conn, callback);
@@ -1057,7 +1057,7 @@ __Example:__ Get a list of users and their posts, excluding any users who have n
 
 Existing table structure:
 
-```js
+```javascript
 [
     { 'id': 1, 'user': 'bob', 'email': 'bob@foo.com', 'posts': [ 1, 4, 5 ] },
     { 'id': 2, 'user': 'george', 'email': 'george@foo.com' },
@@ -1067,7 +1067,7 @@ Existing table structure:
 
 Command and output:
 
-```js
+```javascript
 > r.table('users').withFields('id', 'user', 'posts').run(conn, callback)
 // Result passed to callback
 [
@@ -1089,7 +1089,7 @@ Concatenate one or more elements into a single sequence using a mapping function
 
 __Example:__ Construct a sequence of all monsters defeated by Marvel heroes. The field "defeatedMonsters" is an array of one or more monster names.
 
-```js
+```javascript
 r.table('marvel').concatMap(function(hero) {
     return hero('defeatedMonsters')
 }).run(conn, callback)
@@ -1111,7 +1111,7 @@ the ordering, wrap the attribute with either `r.asc` or `r.desc`
 
 __Example:__ Order all the posts using the index `date`.
 
-```js
+```javascript
 r.table('posts').orderBy({index: 'date'}).run(conn, callback);
 ```
 
@@ -1128,7 +1128,7 @@ Skip a number of elements from the head of the sequence.
 
 __Example:__ Here in conjunction with [orderBy](/api/javascript/order_by/) we choose to ignore the most successful heroes.
 
-```js
+```javascript
 r.table('marvel').orderBy('successMetric').skip(10).run(conn, callback)
 ```
 
@@ -1145,7 +1145,7 @@ End the sequence after the given number of elements.
 
 __Example:__ Only so many can fit in our Pantheon of heroes.
 
-```js
+```javascript
 r.table('marvel').orderBy('belovedness').limit(10).run(conn, callback)
 ```
 
@@ -1165,7 +1165,7 @@ Return the elements of a sequence within the specified range.
 
 __Example:__ Return the fourth, fifth and sixth youngest players. (The youngest player is at index 0, so those are elements 3&ndash;5.)
 
-```js
+```javascript
 r.table('players').orderBy({index: 'age'}).slice(3,6).run(conn, callback);
 ```
 
@@ -1182,7 +1182,7 @@ Get the *nth* element of a sequence, counting from zero. If the argument is nega
 
 __Example:__ Select the second element in the array.
 
-```js
+```javascript
 r.expr([1,2,3]).nth(1).run(conn, callback)
 r.expr([1,2,3])(1).run(conn, callback)
 ```
@@ -1199,7 +1199,7 @@ Get the indexes of an element in a sequence. If the argument is a predicate, get
 
 __Example:__ Find the position of the letter 'c'.
 
-```js
+```javascript
 r.expr(['a','b','c']).offsetsOf('c').run(conn, callback)
 ```
 
@@ -1215,7 +1215,7 @@ Test if a sequence is empty.
 
 __Example:__ Are there any documents in the marvel table?
 
-```js
+```javascript
 r.table('marvel').isEmpty().run(conn, callback)
 ```
 
@@ -1234,7 +1234,7 @@ Merge two or more sequences.
 
 __Example:__ Construct a stream of all heroes.
 
-```js
+```javascript
 r.table('marvel').union(r.table('dc')).run(conn, callback);
 ```
 
@@ -1252,7 +1252,7 @@ Select a given number of elements from a sequence with uniform random distributi
 
 __Example:__ Select 3 random heroes.
 
-```js
+```javascript
 r.table('marvel').sample(3).run(conn, callback)
 ```
 
@@ -1274,7 +1274,7 @@ fields or functions provided.
 
 __Example:__ Group games by player.
 
-```js
+```javascript
 > r.table('games').group('player').run(conn, callback)
 
 // Result passed to callback
@@ -1314,7 +1314,7 @@ the value of their reduction.
 __Example:__ What is the maximum number of points scored by each
 player, with the highest scorers first?
 
-```js
+```javascript
 r.table('games')
    .group('player').max('points')('points')
    .ungroup().orderBy(r.desc('reduction')).run(conn, callback)
@@ -1333,7 +1333,7 @@ Produce a single value from a sequence through repeated application of a reducti
 
 __Example:__ Return the number of documents in the table `posts`.
 
-```js
+```javascript
 r.table("posts").map(function(doc) {
     return 1;
 }).reduce(function(left, right) {
@@ -1356,7 +1356,7 @@ Apply a function to a sequence in order, maintaining state via an accumulator. T
 
 __Example:__ Concatenate words from a list.
 
-```js
+```javascript
 r.table('words').orderBy('id').fold('', function (acc, word) {
     return acc.add(r.branch(acc.eq(''), '', ', ')).add(word);
 }).run(conn, callback);
@@ -1380,7 +1380,7 @@ Counts the number of elements in a sequence or key/value pairs in an object, or 
 
 __Example:__ Count the number of users.
 
-```js
+```javascript
 r.table('users').count().run(conn, callback);
 ```
 
@@ -1402,7 +1402,7 @@ results, skipping elements of the sequence where that function returns
 
 __Example:__ What's 3 + 5 + 7?
 
-```js
+```javascript
 r.expr([3, 5, 7]).sum().run(conn, callback)
 ```
 
@@ -1424,7 +1424,7 @@ function returns `null` or a non-existence error.
 
 __Example:__ What's the average of 3, 5, and 7?
 
-```js
+```javascript
 r.expr([3, 5, 7]).avg().run(conn, callback)
 ```
 
@@ -1443,7 +1443,7 @@ Finds the minimum element of a sequence.
 
 __Example:__ Return the minimum value in the list `[3, 5, 7]`.
 
-```js
+```javascript
 r.expr([3, 5, 7]).min().run(conn, callback);
 ```
 
@@ -1462,7 +1462,7 @@ Finds the maximum element of a sequence.
 
 __Example:__ Return the maximum value in the list `[3, 5, 7]`.
 
-```js
+```javascript
 r.expr([3, 5, 7]).max().run(conn, callback);
 ```
 
@@ -1481,7 +1481,7 @@ Removes duplicates from elements in a sequence.
 
 __Example:__ Which unique villains have been vanquished by Marvel heroes?
 
-```js
+```javascript
 r.table('marvel').concatMap(function(hero) {
     return hero('villainList')
 }).distinct().run(conn, callback)
@@ -1503,7 +1503,7 @@ where that predicate returns `true`.
 
 __Example:__ Has Iron Man ever fought Superman?
 
-```js
+```javascript
 r.table('marvel').get('ironman')('opponents').contains('superman').run(conn, callback);
 ```
 
@@ -1523,7 +1523,7 @@ Returns the currently visited document.
 
 __Example:__ Get all users whose age is greater than 5.
 
-```js
+```javascript
 r.table('users').filter(r.row('age').gt(5)).run(conn, callback)
 ```
 
@@ -1544,7 +1544,7 @@ Plucks out one or more attributes from either an object or a sequence of objects
 __Example:__ We just need information about IronMan's reactor and not the rest of the
 document.
 
-```js
+```javascript
 r.table('marvel').get('IronMan').pluck('reactorState', 'reactorPower').run(conn, callback)
 ```
 
@@ -1565,7 +1565,7 @@ the specified paths removed.
 __Example:__ Since we don't need it for this computation we'll save bandwidth and leave
 out the list of IronMan's romantic conquests.
 
-```js
+```javascript
 r.table('marvel').get('IronMan').without('personalVictoriesList').run(conn, callback)
 ```
 
@@ -1584,7 +1584,7 @@ Merge two or more objects together to construct a new object with properties fro
 
 __Example:__ Equip Thor for battle.
 
-```js
+```javascript
 r.table('marvel').get('thor').merge(
     r.table('equipment').get('hammer'),
     r.table('equipment').get('pimento_sandwich')
@@ -1603,7 +1603,7 @@ Append a value to an array.
 
 __Example:__ Retrieve Iron Man's equipment list with the addition of some new boots.
 
-```js
+```javascript
 r.table('marvel').get('IronMan')('equipment').append('newBoots').run(conn, callback)
 ```
 
@@ -1619,7 +1619,7 @@ Prepend a value to an array.
 
 __Example:__ Retrieve Iron Man's equipment list with the addition of some new boots.
 
-```js
+```javascript
 r.table('marvel').get('IronMan')('equipment').prepend('newBoots').run(conn, callback)
 ```
 
@@ -1635,7 +1635,7 @@ Remove the elements of one array from another array.
 
 __Example:__ Retrieve Iron Man's equipment list without boots.
 
-```js
+```javascript
 r.table('marvel').get('IronMan')('equipment')
   .difference(['Boots'])
   .run(conn, callback)
@@ -1653,7 +1653,7 @@ Add a value to an array and return it as a set (an array with distinct values).
 
 __Example:__ Retrieve Iron Man's equipment list with the addition of some new boots.
 
-```js
+```javascript
 r.table('marvel').get('IronMan')('equipment').setInsert('newBoots').run(conn, callback)
 ```
 
@@ -1669,7 +1669,7 @@ Add a several values to an array and return it as a set (an array with distinct 
 
 __Example:__ Retrieve Iron Man's equipment list with the addition of some new boots and an arc reactor.
 
-```js
+```javascript
 r.table('marvel').get('IronMan')('equipment').setUnion(['newBoots', 'arc_reactor']).run(conn, callback)
 ```
 
@@ -1686,7 +1686,7 @@ distinct values).
 
 __Example:__ Check which pieces of equipment Iron Man has from a fixed list.
 
-```js
+```javascript
 r.table('marvel').get('IronMan')('equipment').setIntersection(['newBoots', 'arc_reactor']).run(conn, callback)
 ```
 
@@ -1703,7 +1703,7 @@ distinct values).
 
 __Example:__ Check which pieces of equipment Iron Man has, excluding a fixed list.
 
-```js
+```javascript
 r.table('marvel').get('IronMan')('equipment').setDifference(['newBoots', 'arc_reactor']).run(conn, callback)
 ```
 
@@ -1722,7 +1722,7 @@ Get a single field from an object. If called on a sequence, gets that field from
 
 __Example:__ What was Iron Man's first appearance in a comic?
 
-```js
+```javascript
 r.table('marvel').get('IronMan')('firstAppearance').run(conn, callback)
 ```
 
@@ -1741,7 +1741,7 @@ object in the sequence, skipping objects that lack it.
 
 __Example:__ What was Iron Man's first appearance in a comic?
 
-```js
+```javascript
 r.table('marvel').get('IronMan').getField('firstAppearance').run(conn, callback)
 ```
 
@@ -1759,7 +1759,7 @@ Test if an object has one or more fields. An object has a field if it has that k
 
 __Example:__ Return the players who have won games.
 
-```js
+```javascript
 r.table('players').hasFields('games_won').run(conn, callback)
 ```
 
@@ -1775,7 +1775,7 @@ Insert a value in to an array at a given index. Returns the modified array.
 
 __Example:__ Hulk decides to join the avengers.
 
-```js
+```javascript
 r.expr(["Iron Man", "Spider-Man"]).insertAt(1, "Hulk").run(conn, callback)
 ```
 
@@ -1791,7 +1791,7 @@ Insert several values in to an array at a given index. Returns the modified arra
 
 __Example:__ Hulk and Thor decide to join the avengers.
 
-```js
+```javascript
 r.expr(["Iron Man", "Spider-Man"]).spliceAt(1, ["Hulk", "Thor"]).run(conn, callback)
 ```
 
@@ -1807,7 +1807,7 @@ Remove one or more elements from an array at a given index. Returns the modified
 
 __Example:__ Delete the second element of an array.
 
-```js
+```javascript
 > r(['a','b','c','d','e','f']).deleteAt(1).run(conn, callback)
 // result passed to callback
 ['a', 'c', 'd', 'e', 'f']
@@ -1825,7 +1825,7 @@ Change a value in an array at a given index. Returns the modified array.
 
 __Example:__ Bruce Banner hulks out.
 
-```js
+```javascript
 r.expr(["Iron Man", "Bruce", "Spider-Man"]).changeAt(1, "Hulk").run(conn, callback)
 ```
 
@@ -1842,7 +1842,7 @@ Return an array containing all of an object's keys. Note that the keys will be s
 
 __Example:__ Get all the keys from a table row.
 
-```js
+```javascript
 // row: { id: 1, mail: "fred@example.com", name: "fred" }
 
 r.table('users').get(1).keys().run(conn, callback);
@@ -1863,7 +1863,7 @@ Return an array containing all of an object's values. `values()` guarantees the 
 
 __Example:__ Get all of the values from a table row.
 
-```js
+```javascript
 // row: { id: 1, mail: "fred@example.com", name: "fred" }
 
 r.table('users').get(1).values().run(conn, callback);
@@ -1883,7 +1883,7 @@ Replace an object in a field instead of merging it with an existing object in a 
 
 __Example:__ Replace one nested document with another rather than merging the fields.
 
-```js
+```javascript
 r.table('users').get(1).update({ data: r.literal({ age: 19, job: 'Engineer' }) }).run(conn, callback)
 
 // Result passed to callback
@@ -1911,13 +1911,13 @@ be strings.  `r.object(A, B, C, D)` is equivalent to
 
 __Example:__ Create a simple object.
 
-```js
+```javascript
 r.object('id', 5, 'data', ['foo', 'bar']).run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 {data: ["foo", "bar"], id: 5}
 ```
 
@@ -1945,7 +1945,7 @@ If no match is found, returns `null`.
 __Example:__ Get all users whose name starts with "A". Because `null` evaluates to `false` in
 [filter](/api/javascript/filter/), you can just use the result of `match` for the predicate.
 
-```js
+```javascript
 r.table('users').filter(function(doc){
     return doc('name').match("^A")
 }).run(conn, callback)
@@ -1968,13 +1968,13 @@ while still specifying `max_splits`.)
 
 __Example:__ Split on whitespace.
 
-```js
+```javascript
 r.expr("foo  bar bax").split().run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 ["foo", "bar", "bax"]
 ```
 
@@ -1990,13 +1990,13 @@ Uppercases a string.
 
 __Example:__
 
-```js
+```javascript
 r.expr("Sentence about LaTeX.").upcase().run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 "SENTENCE ABOUT LATEX."
 ```
 
@@ -2014,13 +2014,13 @@ Lowercases a string.
 
 __Example:__
 
-```js
+```javascript
 r.expr("Sentence about LaTeX.").downcase().run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 "sentence about latex."
 ```
 
@@ -2043,7 +2043,7 @@ Sum two or more numbers, or concatenate two or more strings or arrays.
 
 __Example:__ It's as easy as 2 + 2 = 4.
 
-```js
+```javascript
 > r.expr(2).add(2).run(conn, callback)
 // result passed to callback
 4
@@ -2063,7 +2063,7 @@ Subtract two numbers.
 
 __Example:__ It's as easy as 2 - 2 = 0.
 
-```js
+```javascript
 r.expr(2).sub(2).run(conn, callback)
 ```
 
@@ -2080,7 +2080,7 @@ Multiply two numbers, or make a periodic array.
 
 __Example:__ It's as easy as 2 * 2 = 4.
 
-```js
+```javascript
 r.expr(2).mul(2).run(conn, callback)
 ```
 
@@ -2096,7 +2096,7 @@ Divide two numbers.
 
 __Example:__ It's as easy as 2 / 2 = 1.
 
-```js
+```javascript
 r.expr(2).div(2).run(conn, callback)
 ```
 
@@ -2112,7 +2112,7 @@ number.mod(number) &rarr; number
 
 __Example:__ It's as easy as 2 % 2 = 0.
 
-```js
+```javascript
 r.expr(2).mod(2).run(conn, callback)
 ```
 
@@ -2129,7 +2129,7 @@ Compute the logical "and" of one or more values.
 
 __Example:__ Return whether both `a` and `b` evaluate to true.
 
-```js
+```javascript
 var a = true, b = false;
 r.expr(a).and(b).run(conn, callback);
 // result passed to callback
@@ -2149,7 +2149,7 @@ Compute the logical "or" of one or more values.
 
 __Example:__ Return whether either `a` or `b` evaluate to true.
 
-```js
+```javascript
 var a = true, b = false;
 r.expr(a).or(b).run(conn, callback);
 // result passed to callback
@@ -2168,7 +2168,7 @@ Test if two or more values are equal.
 
 __Example:__ See if a user's `role` field is set to `administrator`.
 
-```js
+```javascript
 r.table('users').get(1)('role').eq('administrator').run(conn, callback);
 ```
 
@@ -2184,7 +2184,7 @@ Test if two or more values are not equal.
 
 __Example:__ See if a user's `role` field is not set to `administrator`.
 
-```js
+```javascript
 r.table('users').get(1)('role').ne('administrator').run(conn, callback);
 ```
 
@@ -2200,7 +2200,7 @@ Compare values, testing if the left-hand value is greater than the right-hand.
 
 __Example:__ Test if a player has scored more than 10 points.
 
-```js
+```javascript
 r.table('players').get(1)('score').gt(10).run(conn, callback);
 ```
 
@@ -2216,7 +2216,7 @@ Compare values, testing if the left-hand value is greater than or equal to the r
 
 __Example:__ Test if a player has scored 10 points or more.
 
-```js
+```javascript
 r.table('players').get(1)('score').ge(10).run(conn, callback);
 ```
 
@@ -2232,7 +2232,7 @@ Compare values, testing if the left-hand value is less than the right-hand.
 
 __Example:__ Test if a player has scored less than 10 points.
 
-```js
+```javascript
 r.table('players').get(1)('score').lt(10).run(conn, callback);
 ```
 
@@ -2248,7 +2248,7 @@ Compare values, testing if the left-hand value is less than or equal to the righ
 
 __Example:__ Test if a player has scored 10 points or less.
 
-```js
+```javascript
 r.table('players').get(1)('score').le(10).run(conn, callback);
 ```
 
@@ -2265,7 +2265,7 @@ Compute the logical inverse (not) of an expression.
 
 __Example:__ Not true is false.
 
-```js
+```javascript
 r(true).not().run(conn, callback)
 r.not(true).run(conn, callback)
 ```
@@ -2286,7 +2286,7 @@ Generate a random number between given (or implied) bounds. `random` takes zero,
 
 __Example:__ Generate a random number in the range `[0,1)`
 
-```js
+```javascript
 r.random().run(conn, callback)
 ```
 
@@ -2303,7 +2303,7 @@ Rounds the given value to the nearest whole integer.
 
 __Example:__ Round 12.345 to the nearest integer.
 
-```js
+```javascript
 r.round(12.345).run(conn, callback);
 // Result passed to callback
 12.0
@@ -2324,7 +2324,7 @@ Rounds the given value up, returning the smallest integer value greater than or 
 
 __Example:__ Return the ceiling of 12.345.
 
-```js
+```javascript
 r.ceil(12.345).run(conn, callback);
 // Result passed to callback
 13.0
@@ -2345,7 +2345,7 @@ Rounds the given value down, returning the largest integer value less than or eq
 
 __Example:__ Return the floor of 12.345.
 
-```js
+```javascript
 r.floor(12.345).run(conn, callback);
 // Result passed to callback
 12.0
@@ -2369,7 +2369,7 @@ Return a time object representing the current time in UTC. The command now() is 
 
 __Example:__ Add a new user with the time at which he subscribed.
 
-```js
+```javascript
 r.table("users").insert({
     name: "John",
     subscription_date: r.now()
@@ -2389,7 +2389,7 @@ Create a time object for a specific time.
 
 __Example:__ Update the birthdate of the user "John" to November 3rd, 1986 UTC.
 
-```js
+```javascript
 r.table("user").get("John").update({birthdate: r.time(1986, 11, 3, 'Z')}).run(conn, callback)
 ```
 
@@ -2406,7 +2406,7 @@ will be rounded to three decimal places (millisecond-precision).
 
 __Example:__ Update the birthdate of the user "John" to November 3rd, 1986.
 
-```js
+```javascript
 r.table("user").get("John").update({birthdate: r.epochTime(531360000)}).run(conn, callback)
 ```
 
@@ -2422,7 +2422,7 @@ Create a time object based on an ISO 8601 date-time string (e.g. '2013-01-01T01:
 
 __Example:__ Update the time of John's birth.
 
-```js
+```javascript
 r.table("user").get("John").update({birth: r.ISO8601('1986-11-03T08:30:00-07:00')}).run(conn, callback)
 ```
 
@@ -2438,7 +2438,7 @@ Return a new time object with a different timezone. While the time stays the sam
 
 __Example:__ Hour of the day in San Francisco (UTC/GMT -8, without daylight saving time).
 
-```js
+```javascript
 r.now().inTimezone('-08:00').hours().run(conn, callback)
 ```
 
@@ -2454,7 +2454,7 @@ Return the timezone of the time object.
 
 __Example:__ Return all the users in the "-07:00" timezone.
 
-```js
+```javascript
 r.table("users").filter( function(user) {
     return user("subscriptionDate").timezone().eq("-07:00")
 })
@@ -2473,7 +2473,7 @@ Return whether a time is between two other times.
 __Example:__ Retrieve all the posts that were posted between December 1st, 2013
 (inclusive) and December 10th, 2013 (exclusive).
 
-```js
+```javascript
 r.table("posts").filter(
     r.row('date').during(r.time(2013, 12, 1, "Z"), r.time(2013, 12, 10, "Z"))
 ).run(conn, callback)
@@ -2491,7 +2491,7 @@ Return a new time object only based on the day, month and year (ie. the same day
 
 __Example:__ Retrieve all the users whose birthday is today.
 
-```js
+```javascript
 r.table("users").filter(function(user) {
     return user("birthdate").date().eq(r.now().date())
 }).run(conn, callback)
@@ -2509,7 +2509,7 @@ Return the number of seconds elapsed since the beginning of the day stored in th
 
 __Example:__ Retrieve posts that were submitted before noon.
 
-```js
+```javascript
 r.table("posts").filter(
     r.row("date").timeOfDay().le(12*60*60)
 ).run(conn, callback)
@@ -2527,7 +2527,7 @@ Return the year of a time object.
 
 __Example:__ Retrieve all the users born in 1986.
 
-```js
+```javascript
 r.table("users").filter(function(user) {
     return user("birthdate").year().eq(1986)
 }).run(conn, callback)
@@ -2545,7 +2545,7 @@ Return the month of a time object as a number between 1 and 12. For your conveni
 
 __Example:__ Retrieve all the users who were born in November.
 
-```js
+```javascript
 r.table("users").filter(
     r.row("birthdate").month().eq(11)
 )
@@ -2563,7 +2563,7 @@ Return the day of a time object as a number between 1 and 31.
 
 __Example:__ Return the users born on the 24th of any month.
 
-```js
+```javascript
 r.table("users").filter(
     r.row("birthdate").day().eq(24)
 ).run(conn, callback)
@@ -2581,7 +2581,7 @@ Return the day of week of a time object as a number between 1 and 7 (following I
 
 __Example:__ Return today's day of week.
 
-```js
+```javascript
 r.now().dayOfWeek().run(conn, callback)
 ```
 
@@ -2597,7 +2597,7 @@ Return the day of the year of a time object as a number between 1 and 366 (follo
 
 __Example:__ Retrieve all the users who were born the first day of a year.
 
-```js
+```javascript
 r.table("users").filter(
     r.row("birthdate").dayOfYear().eq(1)
 )
@@ -2615,7 +2615,7 @@ Return the hour in a time object as a number between 0 and 23.
 
 __Example:__ Return all the posts submitted after midnight and before 4am.
 
-```js
+```javascript
 r.table("posts").filter(function(post) {
     return post("date").hours().lt(4)
 })
@@ -2633,7 +2633,7 @@ Return the minute in a time object as a number between 0 and 59.
 
 __Example:__ Return all the posts submitted during the first 10 minutes of every hour.
 
-```js
+```javascript
 r.table("posts").filter(function(post) {
     return post("date").minutes().lt(10)
 })
@@ -2651,7 +2651,7 @@ Return the seconds in a time object as a number between 0 and 59.999 (double pre
 
 __Example:__ Return the post submitted during the first 30 seconds of every minute.
 
-```js
+```javascript
 r.table("posts").filter(function(post) {
     return post("date").seconds().lt(30)
 })
@@ -2669,7 +2669,7 @@ Convert a time object to a string in ISO 8601 format.
 
 __Example:__ Return the current ISO 8601 time.
 
-```js
+```javascript
 r.now().toISO8601().run(conn, callback)
 // Result passed to callback
 "2015-04-20T18:37:52.690+00:00"
@@ -2687,7 +2687,7 @@ Convert a time object to its epoch time.
 
 __Example:__ Return the current time in seconds since the Unix Epoch with millisecond-precision.
 
-```js
+```javascript
 r.now().toEpochTime()
 ```
 
@@ -2709,7 +2709,7 @@ term such as [getAll](/api/javascript/get_all/) with a set of arguments produced
 
 __Example:__ Get Alice and Bob from the table `people`.
 
-```js
+```javascript
 r.table('people').getAll('Alice', 'Bob').run(conn, callback)
 // or
 r.table('people').getAll(r.args(['Alice', 'Bob'])).run(conn, callback)
@@ -2727,7 +2727,7 @@ Encapsulate binary data within a query.
 
 __Example:__ Save an avatar image to a existing user record.
 
-```js
+```javascript
 var fs = require('fs');
 fs.readFile('./defaultAvatar.png', function (err, avatarImage) {
     if (err) {
@@ -2756,7 +2756,7 @@ Call an anonymous function using return values from other ReQL commands or queri
 
 __Example:__ Compute a golfer's net score for a game.
 
-```js
+```javascript
 r.table('players').get('f19b5f16-ef14-468f-bd48-e194761df255').do(
     function (player) {
         return player('gross_score').sub(player('course_handicap'));
@@ -2779,7 +2779,7 @@ The `branch` command takes 2n+1 arguments: pairs of conditional expressions and 
 
 __Example:__ Test the value of x.
 
-```js
+```javascript
 var x = 10;
 r.branch(r.expr(x).gt(5), 'big', 'small').run(conn, callback);
 // Result passed to callback
@@ -2798,7 +2798,7 @@ Loop over a sequence, evaluating the given write query for each element.
 
 __Example:__ Now that our heroes have defeated their villains, we can safely remove them from the villain table.
 
-```js
+```javascript
 r.table('marvel').forEach(function(hero) {
     return r.table('villains').get(hero('villainDefeated')).delete()
 }).run(conn, callback)
@@ -2817,7 +2817,7 @@ Generate a stream of sequential integers in a specified range.
 
 __Example:__ Return a four-element range of `[0, 1, 2, 3]`.
 
-```js
+```javascript
 > r.range(4).run(conn, callback)
 // result returned to callback
 [0, 1, 2, 3]
@@ -2835,7 +2835,7 @@ Throw a runtime error. If called with no arguments inside the second argument to
 
 __Example:__ Iron Man can't possibly have lost a battle:
 
-```js
+```javascript
 r.table('marvel').get('IronMan').do(function(ironman) {
     return r.branch(ironman('victories').lt(ironman('battles')),
         r.error('impossible code path'),
@@ -2858,7 +2858,7 @@ __Example:__ Retrieve the titles and authors of the table `posts`.
 In the case where the author field is missing or `null`, we want to retrieve the string
 `Anonymous`.
 
-```js
+```javascript
 r.table("posts").map(function (post) {
     return {
         title: post("title"),
@@ -2879,7 +2879,7 @@ Construct a ReQL JSON object from a native object.
 
 __Example:__ Objects wrapped with `expr` can then be manipulated by ReQL API functions.
 
-```js
+```javascript
 r.expr({a:'b'}).merge({b:[1,2,3]}).run(conn, callback)
 ```
 
@@ -2895,7 +2895,7 @@ Create a javascript expression.
 
 __Example:__ Concatenate two strings using JavaScript.
 
-```js
+```javascript
 r.js("'str1' + 'str2'").run(conn, callback)
 ```
 
@@ -2918,7 +2918,7 @@ Convert a value of one type into another.
 
 __Example:__ Coerce a stream to an array to store its output in a field. (A stream cannot be stored in a field directly.)
 
-```js
+```javascript
 r.table('posts').map(function (post) {
     return post.merge({ comments: r.table('comments').getAll(post('id'), {index: 'postId'}).coerceTo('array')});
 }).run(conn, callback)
@@ -2936,7 +2936,7 @@ Gets the type of a ReQL query's return value.
 
 __Example:__ Get the type of a string.
 
-```js
+```javascript
 r.expr("foo").typeOf().run(conn, callback);
 // Result passed to callback
 "STRING"
@@ -2955,7 +2955,7 @@ Get information about a ReQL value.
 
 __Example:__ Get information about a table such as primary key, or cache size.
 
-```js
+```javascript
 r.table('marvel').info().run(conn, callback)
 ```
 
@@ -2971,7 +2971,7 @@ Parse a JSON string on the server.
 
 __Example:__ Send an array to the server.
 
-```js
+```javascript
 r.json("[1,2,3]").run(conn, callback)
 ```
 
@@ -2988,7 +2988,7 @@ Convert a ReQL value or object to a JSON string. You may use either `toJsonStrin
 
 __Example:__ Get a ReQL document as a JSON string.
 
-```js
+```javascript
 > r.table('hero').get(1).toJSON()
 // result returned to callback
 '{"id": 1, "name": "Batman", "city": "Gotham", "powers": ["martial arts", "cinematic entrances"]}'
@@ -3007,7 +3007,7 @@ Retrieve data from the specified URL over HTTP.  The return type depends on the 
 
 __Example:__ Perform an HTTP `GET` and store the result in a table.
 
-```js
+```javascript
 r.table('posts').insert(r.http('http://httpbin.org/get')).run(conn, callback)
 ```
 
@@ -3023,7 +3023,7 @@ Return a UUID (universally unique identifier), a string that can be used as a un
 
 __Example:__ Generate a UUID.
 
-```js
+```javascript
 > r.uuid().run(conn, callback)
 // result returned to callback
 "27961a0e-f4e8-4eb3-bf95-c5203e1d87b9"
@@ -3046,7 +3046,7 @@ Construct a circular line or polygon. A circle in RethinkDB is a polygon or line
 
 __Example:__ Define a circle.
 
-```js
+```javascript
 r.table('geo').insert({
     id: 300,
     name: 'Hayes Valley',
@@ -3067,7 +3067,7 @@ Compute the distance between a point and another geometry object. At least one o
 
 __Example:__ Compute the distance between two points on the Earth in kilometers.
 
-```js
+```javascript
 var point1 = r.point(-122.423246,37.779388);
 var point2 = r.point(-117.220406,32.719464);
 r.distance(point1, point2, {unit: 'km'}).run(conn, callback);
@@ -3087,7 +3087,7 @@ Convert a Line object into a Polygon object. If the last point does not specify 
 
 __Example:__ Create a line object and then convert it to a polygon.
 
-```js
+```javascript
 r.table('geo').insert({
     id: 201,
     rectangle: r.line(
@@ -3115,7 +3115,7 @@ Convert a [GeoJSON](http://geojson.org) object to a ReQL geometry object.
 
 __Example:__ Convert a GeoJSON object to a ReQL geometry object.
 
-```js
+```javascript
 var geoJson = {
     'type': 'Point',
     'coordinates': [ -122.423246, 37.779388 ]
@@ -3139,7 +3139,7 @@ Convert a ReQL geometry object to a [GeoJSON](http://geojson.org) object.
 
 __Example:__ Convert a ReQL geometry object to a GeoJSON object.
 
-```js
+```javascript
 r.table('geo').get('sfo')('location').toGeojson.run(conn, callback);
 // result passed to callback
 {
@@ -3160,7 +3160,7 @@ Get all documents where the given geometry object intersects the geometry object
 
 __Example:__ Which of the locations in a list of parks intersect `circle1`?
 
-```js
+```javascript
 var circle1 = r.circle([-117.220406,32.719464], 10, {unit: 'mi'});
 r.table('parks').getIntersecting(circle1, {index: 'area'}).run(conn, callback);
 ```
@@ -3177,7 +3177,7 @@ Return a list of documents closest to a specified point based on a geospatial in
 
 __Example:__ Return a list of the closest 25 enemy hideouts to the secret base.
 
-```js
+```javascript
 var secretBase = r.point(-122.422876,37.777128);
 r.table('hideouts').getNearest(secretBase,
     {index: 'location', maxResults: 25}
@@ -3197,7 +3197,7 @@ Tests whether a geometry object is completely contained within another. When app
 
 __Example:__ Is `point2` included within a 2000-meter circle around `point1`?
 
-```js
+```javascript
 var point1 = r.point(-117.220406,32.719464);
 var point2 = r.point(-117.206201,32.725186);
 r.circle(point1, 2000).includes(point2).run(conn, callback);
@@ -3220,7 +3220,7 @@ Tests whether two geometry objects intersect with one another. When applied to a
 
 __Example:__ Is `point2` within a 2000-meter circle around `point1`?
 
-```js
+```javascript
 var point1 = r.point(-117.220406,32.719464);
 var point2 = r.point(-117.206201,32.725186);
 r.circle(point1, 2000).intersects(point2).run(conn, callback);
@@ -3244,7 +3244,7 @@ Construct a geometry object of type Line. The line can be specified in one of tw
 
 __Example:__ Define a line.
 
-```js
+```javascript
 r.table('geo').insert({
     id: 101,
     route: r.line([-122.423246,37.779388], [-121.886420,37.329898])
@@ -3263,7 +3263,7 @@ Construct a geometry object of type Point. The point is specified by two floatin
 
 __Example:__ Define a point.
 
-```js
+```javascript
 r.table('geo').insert({
     id: 1,
     name: 'San Francisco',
@@ -3287,7 +3287,7 @@ Construct a geometry object of type Polygon. The Polygon can be specified in one
 
 __Example:__ Define a polygon.
 
-```js
+```javascript
 r.table('geo').insert({
     id: 101,
     rectangle: r.polygon(
@@ -3311,7 +3311,7 @@ Use `polygon2` to "punch out" a hole in `polygon1`. `polygon2` must be completel
 
 __Example:__ Define a polygon with a hole punched in it.
 
-```js
+```javascript
 var outerPolygon = r.polygon(
     [-122.4,37.7],
     [-122.4,37.3],
@@ -3345,7 +3345,7 @@ Grant or deny access permissions for a user account, globally or on a per-databa
 
 __Example:__ Grant the `chatapp` user account read and write permissions on the `users` database.
 
-```js
+```javascript
 r.db('users').grant('chatapp', {read: true, write: true}).run(conn, callback);
 
 // Result passed to callback
@@ -3372,7 +3372,7 @@ Query (read and/or update) the configurations for individual tables or databases
 
 __Example:__ Get the configuration for the `users` table.
 
-```js
+```javascript
 > r.table('users').config().run(conn, callback);
 ```
 
@@ -3389,7 +3389,7 @@ Rebalances the shards of a table. When called on a database, all the tables in t
 
 __Example:__ Rebalance a table.
 
-```js
+```javascript
 > r.table('superheroes').rebalance().run(conn, callback);
 ```
 
@@ -3407,7 +3407,7 @@ Reconfigure a table's sharding and replication.
 
 __Example:__ Reconfigure a table.
 
-```js
+```javascript
 > r.table('superheroes').reconfigure({shards: 2, replicas: 1}).run(conn, callback);
 ```
 
@@ -3423,7 +3423,7 @@ Return the status of a table.
 
 __Example:__ Get a table's status.
 
-```js
+```javascript
 > r.table('superheroes').status().run(conn, callback);
 ```
 
@@ -3441,7 +3441,7 @@ Wait for a table or all the tables in a database to be ready. A table may be tem
 
 __Example:__ Wait on a table to be ready.
 
-```js
+```javascript
 > r.table('superheroes').wait().run(conn, callback);
 // Result passed to callback
 { "ready": 1 }

--- a/api/javascript/joins/eq_join.md
+++ b/api/javascript/joins/eq_join.md
@@ -34,7 +34,7 @@ The results from `eqJoin` are, by default, not ordered. The optional `ordered: t
 
 Suppose the players table contains these documents:
 
-```js
+```javascript
 [
     { id: 1, player: 'George', gameId: 1 },
     { id: 2, player: 'Agatha', gameId: 3 },
@@ -47,7 +47,7 @@ Suppose the players table contains these documents:
 
 The games table contains these documents:
 
-```js
+```javascript
 [
     { id: 1, field: 'Little Delving' },
     { id: 2, field: 'Rushock Bog' },
@@ -59,13 +59,13 @@ __Example:__ Match players with the games they've played against one another.
 
 Join these tables using `gameId` on the player table and `id` on the games table:
 
-```js
+```javascript
 r.table('players').eqJoin('gameId', r.table('games')).run(conn, callback)
 ```
 
 This will return a result set such as the following:
 
-```js
+```javascript
 [
     {
         "left" : { "gameId" : 3, "id" : 2, "player" : "Agatha" },
@@ -83,7 +83,7 @@ This will return a result set such as the following:
 
 What you likely want is the result of using `zip` with that. For clarity, we'll use `without` to drop the `id` field from the games table (it conflicts with the `id` field for the players and it's redundant anyway), and we'll order it by the games.
 
-```js
+```javascript
 r.table('players').eqJoin('gameId', r.table('games')).without({right: "id"}).zip().orderBy('gameId').run(conn, callback)
 
 [
@@ -100,13 +100,13 @@ For more information, see [Table joins in RethinkDB](/docs/table-joins/).
 
 __Example:__ Use a secondary index on the right table rather than the primary key. If players have a secondary index on their cities, we can get a list of arenas with players in the same area.
 
-```js
+```javascript
 r.table('players').eqJoin('cityId', r.table('arenas'), {index: 'cityId'}).run(conn, callback)
 ```
 
 __Example:__ Use a nested key as the join field. Suppose the documents in the players table were structured like this:
 
-```js
+```javascript
 { id: 1, player: 'George', game: {id: 1} },
 { id: 2, player: 'Agatha', game: {id: 3} },
 ...
@@ -114,7 +114,7 @@ __Example:__ Use a nested key as the join field. Suppose the documents in the pl
 
 Simply specify the field using the `row` command instead of a string.
 
-```js
+```javascript
 r.table('players').eqJoin(r.row('game')('id'), r.table('games')).without({right: 'id'}).zip()
 
 [
@@ -126,7 +126,7 @@ r.table('players').eqJoin(r.row('game')('id'), r.table('games')).without({right:
 
 __Example:__ Use a function instead of a field to join on a more complicated expression. Suppose the players have lists of favorite games ranked in order in a field such as `favorites: [3, 2, 1]`. Get a list of players and their top favorite:
 
-```js
+```javascript
 r.table('players').eqJoin(function (player) {
     return player('favorites').nth(0)
 }, r.table('games')).without([{left: ['favorites', 'gameId', 'id']}, {right: 'id'}]).zip()
@@ -134,7 +134,7 @@ r.table('players').eqJoin(function (player) {
 
 Result:
 
-```js
+```javascript
 [
 	{ "field": "Rushock Bog", "name": "Fred" },
 	{ "field": "Little Delving", "name": "George" },

--- a/api/javascript/joins/inner_join.md
+++ b/api/javascript/joins/inner_join.md
@@ -33,7 +33,7 @@ Note that `innerJoin` is slower and much less efficient than using [eqJoin](/api
 
 __Example:__ Return a list of all matchups between Marvel and DC heroes in which the DC hero could beat the Marvel hero in a fight.
 
-```js
+```javascript
 r.table('marvel').innerJoin(r.table('dc'), function(marvelRow, dcRow) {
     return marvelRow('strength').lt(dcRow('strength'))
 }).zip().run(conn, callback)

--- a/api/javascript/joins/outer_join.md
+++ b/api/javascript/joins/outer_join.md
@@ -32,7 +32,7 @@ Note that `outerJoin` is slower and much less efficient than using [concatMap](/
 
 __Example:__ Return a list of all Marvel heroes, paired with any DC heroes who could beat them in a fight.
 
-```js
+```javascript
 r.table('marvel').outerJoin(r.table('dc'), function(marvelRow, dcRow) {
     return marvelRow('strength').lt(dcRow('strength'))
 }).run(conn, callback)

--- a/api/javascript/joins/zip.md
+++ b/api/javascript/joins/zip.md
@@ -27,7 +27,7 @@ Used to 'zip' up the result of a join by merging the 'right' fields into 'left' 
 
 __Example:__ 'zips up' the sequence by merging the left and right fields produced by a join.
 
-```js
+```javascript
 r.table('marvel').eqJoin('main_dc_collaborator', r.table('dc'))
     .zip().run(conn, callback)
 ```

--- a/api/javascript/manipulating-databases/db_create.md
+++ b/api/javascript/manipulating-databases/db_create.md
@@ -36,7 +36,7 @@ Note: Only alphanumeric characters and underscores are valid for the database na
 
 __Example:__ Create a database named 'superheroes'.
 
-```js
+```javascript
 > r.dbCreate('superheroes').run(conn, callback);
 // Result passed to callback
 {

--- a/api/javascript/manipulating-databases/db_drop.md
+++ b/api/javascript/manipulating-databases/db_drop.md
@@ -34,7 +34,7 @@ If the given database does not exist, the command throws `ReqlRuntimeError`.
 
 __Example:__ Drop a database named 'superheroes'.
 
-```js
+```javascript
 > r.dbDrop('superheroes').run(conn, callback);
 // Result passed to callback
 {

--- a/api/javascript/manipulating-databases/db_list.md
+++ b/api/javascript/manipulating-databases/db_list.md
@@ -24,6 +24,6 @@ List all database names in the system. The result is a list of strings.
 
 __Example:__ List all databases.
 
-```js
+```javascript
 r.dbList().run(conn, callback)
 ```

--- a/api/javascript/manipulating-tables/changes.md
+++ b/api/javascript/manipulating-tables/changes.md
@@ -48,7 +48,7 @@ If the table becomes unavailable, the changefeed will be disconnected, and a run
 
 Changefeed notifications take the form of a two-field object:
 
-```js
+```javascript
 {
     "old_val": <document before change>,
     "new_val": <document after change>
@@ -57,7 +57,7 @@ Changefeed notifications take the form of a two-field object:
 
 When `includeTypes` is `true`, there will be three fields:
 
-```js
+```javascript
 {
     "old_val": <document before change>,
     "new_val": <document after change>,
@@ -81,7 +81,7 @@ __Example:__ Subscribe to the changes on a table.
 
 Start monitoring the changefeed in one client:
 
-```js
+```javascript
 r.table('games').changes().run(conn, function(err, cursor) {
   cursor.each(console.log);
 });
@@ -90,7 +90,7 @@ r.table('games').changes().run(conn, function(err, cursor) {
 As these queries are performed in a second client, the first
 client would receive and print the following objects:
 
-```js
+```javascript
 > r.table('games').insert({id: 1}).run(conn, callback);
 {old_val: null, new_val: {id: 1}}
 
@@ -110,7 +110,7 @@ ReqlRuntimeError: Changefeed aborted (table unavailable)
 
 __Example:__ Return all the changes that increase a player's score.
 
-```js
+```javascript
 r.table('test').changes().filter(
   r.row('new_val')('score').gt(r.row('old_val')('score'))
 ).run(conn, callback)
@@ -118,19 +118,19 @@ r.table('test').changes().filter(
 
 __Example:__ Return all the changes to a specific player's score that increase it past 10.
 
-```js
+```javascript
 r.table('test').get(1).filter(r.row('score').gt(10)).changes().run(conn, callback)
 ```
 
 __Example:__ Return all the inserts on a table.
 
-```js
+```javascript
 r.table('test').changes().filter(r.row('old_val').eq(null)).run(conn, callback)
 ```
 
 __Example:__ Return all the changes to game 1, with state notifications and initial values.
 
-```js
+```javascript
 r.table('games').get(1).changes({includeInitial: true, includeStates: true}).run(conn, callback);
 // Result returned on changefeed
 {state: 'initializing'}
@@ -148,7 +148,7 @@ r.table('games').get(1).changes({includeInitial: true, includeStates: true}).run
 
 __Example:__ Return all the changes to the top 10 games. This assumes the presence of a `score` secondary index on the `games` table.
 
-```js
+```javascript
 r.table('games').orderBy(
     { index: r.desc('score') }
 ).limit(10).changes().run(conn, callback);
@@ -156,7 +156,7 @@ r.table('games').orderBy(
 
 __Example:__ Maintain the state of an array based on a changefeed.
 
-```js
+```javascript
 r.table('data').changes(
     {includeInitial: true, includeOffsets: true}
 ).run(conn, function (err, change) {

--- a/api/javascript/manipulating-tables/index_create.md
+++ b/api/javascript/manipulating-tables/index_create.md
@@ -42,13 +42,13 @@ Note that an index may not be immediately available after creation. If your appl
 
 __Example:__ Create a simple index based on the field `postId`.
 
-```js
+```javascript
 r.table('comments').indexCreate('postId').run(conn, callback)
 ```
 
 __Example:__ Create a geospatial index based on the field `location`.
 
-```js
+```javascript
 r.table('places').indexCreate('location', {geo: true}).run(conn, callback)
 ```
 
@@ -56,32 +56,32 @@ A geospatial index field should contain only geometry objects. It will work with
 
 __Example:__ Create a simple index based on the nested field `author > name`.
 
-```js
+```javascript
 r.table('comments').indexCreate('authorName', r.row("author")("name")).run(conn, callback)
 ```
 
 
 __Example:__ Create a compound index based on the fields `postId` and `date`.
 
-```js
+```javascript
 r.table('comments').indexCreate('postAndDate', [r.row("postId"), r.row("date")]).run(conn, callback)
 ```
 
 __Example:__ Create a multi index based on the field `authors`.
 
-```js
+```javascript
 r.table('posts').indexCreate('authors', {multi: true}).run(conn, callback)
 ```
 
 __Example:__ Create a geospatial multi index based on the field `towers`.
 
-```js
+```javascript
 r.table('networks').indexCreate('towers', {multi: true, geo: true}).run(conn, callback)
 ```
 
 __Example:__ Create an index based on an arbitrary expression.
 
-```js
+```javascript
 r.table('posts').indexCreate('authors', function(doc) {
     return r.branch(
         doc.hasFields("updatedAt"),
@@ -93,7 +93,7 @@ r.table('posts').indexCreate('authors', function(doc) {
 
 __Example:__ Create a new secondary index based on an existing one.
 
-```js
+```javascript
 r.table('posts').indexStatus('authors').nth(0)('function').run(conn, function (func) {
     r.table('newPosts').indexCreate('authors', func).run(conn, callback);
 });
@@ -101,7 +101,7 @@ r.table('posts').indexStatus('authors').nth(0)('function').run(conn, function (f
 
 __Example:__ Rebuild an outdated secondary index on a table.
 
-```js
+```javascript
 r.table('posts').indexStatus('oldIndex').nth(0).do(function(oldIndex) {
   return r.table('posts').indexCreate('newIndex', oldIndex("function")).do(function() {
     return r.table('posts').indexWait('newIndex').do(function() {

--- a/api/javascript/manipulating-tables/index_drop.md
+++ b/api/javascript/manipulating-tables/index_drop.md
@@ -24,7 +24,7 @@ Delete a previously created secondary index of this table.
 
 __Example:__ Drop a secondary index named 'code_name'.
 
-```js
+```javascript
 r.table('dc').indexDrop('code_name').run(conn, callback)
 ```
 

--- a/api/javascript/manipulating-tables/index_list.md
+++ b/api/javascript/manipulating-tables/index_list.md
@@ -25,7 +25,7 @@ List all the secondary indexes of this table.
 
 __Example:__ List the available secondary indexes for this table.
 
-```js
+```javascript
 r.table('marvel').indexList().run(conn, callback)
 ```
 

--- a/api/javascript/manipulating-tables/index_rename.md
+++ b/api/javascript/manipulating-tables/index_rename.md
@@ -30,6 +30,6 @@ An error will be raised if the old index name does not exist, if the new index n
 
 __Example:__ Rename an index on the comments table.
 
-```js
+```javascript
 r.table('comments').indexRename('postId', 'messageId').run(conn, callback)
 ```

--- a/api/javascript/manipulating-tables/index_status.md
+++ b/api/javascript/manipulating-tables/index_status.md
@@ -24,7 +24,7 @@ of all indexes on this table if no indexes are specified.
 
 The result is an array where for each index, there will be an object like this one:
 
-```js
+```javascript
 {
     index: <indexName>,
     ready: true,
@@ -37,7 +37,7 @@ The result is an array where for each index, there will be an object like this o
 
 or this one:
 
-```js
+```javascript
 {
     index: <indexName>,
     ready: false,
@@ -55,19 +55,19 @@ The `function` field is a binary object containing an opaque representation of t
 
 __Example:__ Get the status of all the indexes on `test`:
 
-```js
+```javascript
 r.table('test').indexStatus().run(conn, callback)
 ```
 
 __Example:__ Get the status of the `timestamp` index:
 
-```js
+```javascript
 r.table('test').indexStatus('timestamp').run(conn, callback)
 ```
 
 __Example:__ Save the binary representation of the index:
 
-```js
+```javascript
 var func;
 r.table('test').indexStatus('timestamp').run(conn, function (err, res) {
     func = res[0].function;

--- a/api/javascript/manipulating-tables/index_wait.md
+++ b/api/javascript/manipulating-tables/index_wait.md
@@ -24,7 +24,7 @@ indexes on this table to be ready if no indexes are specified.
 
 The result is an array containing one object for each table index:
 
-```js
+```javascript
 {
     index: <indexName>,
     ready: true,
@@ -39,12 +39,12 @@ See the [indexStatus](/api/javascript/index_status) documentation for a descript
 
 __Example:__ Wait for all indexes on the table `test` to be ready:
 
-```js
+```javascript
 r.table('test').indexWait().run(conn, callback)
 ```
 
 __Example:__ Wait for the index `timestamp` to be ready:
 
-```js
+```javascript
 r.table('test').indexWait('timestamp').run(conn, callback)
 ```

--- a/api/javascript/manipulating-tables/table_create.md
+++ b/api/javascript/manipulating-tables/table_create.md
@@ -57,7 +57,7 @@ Tables will be available for writing when the command returns.
 
 __Example:__ Create a table named 'dc_universe' with the default settings.
 
-```js
+```javascript
 > r.db('heroes').tableCreate('dc_universe').run(conn, callback);
 // Result passed to callback
 {
@@ -89,13 +89,13 @@ __Example:__ Create a table named 'dc_universe' with the default settings.
 
 __Example:__ Create a table named 'dc_universe' using the field 'name' as primary key.
 
-```js
+```javascript
 r.db('test').tableCreate('dc_universe', {primaryKey: 'name'}).run(conn, callback);
 ```
 
 __Example:__ Create a table set up for two shards and three replicas per shard. This requires three available servers.
 
-```js
+```javascript
 r.db('test').tableCreate('dc_universe', {shards: 2, replicas: 3}).run(conn, callback);
 ```
 

--- a/api/javascript/manipulating-tables/table_drop.md
+++ b/api/javascript/manipulating-tables/table_drop.md
@@ -32,7 +32,7 @@ If the given table does not exist in the database, the command throws `ReqlRunti
 
 __Example:__ Drop a table named 'dc_universe'.
 
-```js
+```javascript
 > r.db('test').tableDrop('dc_universe').run(conn, callback);
 // Result passed to callback
 {

--- a/api/javascript/manipulating-tables/table_list.md
+++ b/api/javascript/manipulating-tables/table_list.md
@@ -23,7 +23,7 @@ List all table names in a database. The result is a list of strings.
 
 __Example:__ List all tables of the 'test' database.
 
-```js
+```javascript
 r.db('test').tableList().run(conn, callback)
 ```
 

--- a/api/javascript/math-and-logic/add.md
+++ b/api/javascript/math-and-logic/add.md
@@ -36,7 +36,7 @@ The `add` command can be called in either prefix or infix form; both forms are e
 
 __Example:__ It's as easy as 2 + 2 = 4.
 
-```js
+```javascript
 > r.expr(2).add(2).run(conn, callback)
 // result passed to callback
 4
@@ -44,7 +44,7 @@ __Example:__ It's as easy as 2 + 2 = 4.
 
 __Example:__ Concatenate strings.
 
-```js
+```javascript
 > r.expr("foo").add("bar", "baz").run(conn, callback)
 // result passed to callback
 "foobarbaz"
@@ -53,7 +53,7 @@ __Example:__ Concatenate strings.
 
 __Example:__ Concatenate arrays.
 
-```js
+```javascript
 > r.expr(["foo", "bar"]).add(["buzz"]).run(conn, callback)
 // result passed to callback
 [ "foo", "bar", "buzz" ]
@@ -62,13 +62,13 @@ __Example:__ Concatenate arrays.
 
 __Example:__ Create a date one year from now.
 
-```js
+```javascript
 r.now().add(365*24*60*60).run(conn, callback)
 ```
 
 __Example:__ Use [args](/api/javascript/args) with `add` to sum multiple values.
 
-```js
+```javascript
 > vals = [10, 20, 30];
 > r.add(r.args(vals)).run(conn, callback);
 // result passed to callback
@@ -77,7 +77,7 @@ __Example:__ Use [args](/api/javascript/args) with `add` to sum multiple values.
 
 __Example:__ Concatenate an array of strings with `args`.
 
-```js
+```javascript
 > vals = ['foo', 'bar', 'buzz'];
 > r.add(r.args(vals)).run(conn, callback);
 // result passed to callback

--- a/api/javascript/math-and-logic/and.md
+++ b/api/javascript/math-and-logic/and.md
@@ -29,7 +29,7 @@ Calling `and` with zero arguments will return `true`.
 
 __Example:__ Return whether both `a` and `b` evaluate to true.
 
-```js
+```javascript
 var a = true, b = false;
 r.expr(a).and(b).run(conn, callback);
 // result passed to callback
@@ -38,7 +38,7 @@ false
 
 __Example:__ Return whether all of `x`, `y` and `z` evaluate to true.
 
-```js
+```javascript
 var x = true, y = true, z = true;
 r.and(x, y, z).run(conn, callback);
 // result passed to callback

--- a/api/javascript/math-and-logic/ceil.md
+++ b/api/javascript/math-and-logic/ceil.md
@@ -23,7 +23,7 @@ Rounds the given value up, returning the smallest integer value greater than or 
 
 __Example:__ Return the ceiling of 12.345.
 
-```js
+```javascript
 r.ceil(12.345).run(conn, callback);
 // Result passed to callback
 13.0
@@ -33,7 +33,7 @@ The `ceil` command can also be chained after an expression.
 
 __Example:__ Return the ceiling of -12.345.
 
-```js
+```javascript
 r.expr(-12.345).ceil().run(conn, callback);
 // Result passed to callback
 -12.0
@@ -41,6 +41,6 @@ r.expr(-12.345).ceil().run(conn, callback);
 
 __Example:__ Return Iron Man's weight, rounded up with `ceil`.
 
-```js
+```javascript
 r.table('superheroes').get('ironman')('weight').ceil().run(conn, callback);
 ```

--- a/api/javascript/math-and-logic/div.md
+++ b/api/javascript/math-and-logic/div.md
@@ -25,7 +25,7 @@ Divide two numbers.
 
 __Example:__ It's as easy as 2 / 2 = 1.
 
-```js
+```javascript
 r.expr(2).div(2).run(conn, callback)
 ```
 

--- a/api/javascript/math-and-logic/eq.md
+++ b/api/javascript/math-and-logic/eq.md
@@ -24,12 +24,12 @@ Test if two or more values are equal.
 
 __Example:__ See if a user's `role` field is set to `administrator`. 
 
-```js
+```javascript
 r.table('users').get(1)('role').eq('administrator').run(conn, callback);
 ```
 
 __Example:__ See if three variables contain equal values.
 
-```js
+```javascript
 r.eq(a, b, c).run(conn, callback);
 ```

--- a/api/javascript/math-and-logic/floor.md
+++ b/api/javascript/math-and-logic/floor.md
@@ -23,7 +23,7 @@ Rounds the given value down, returning the largest integer value less than or eq
 
 __Example:__ Return the floor of 12.345.
 
-```js
+```javascript
 r.floor(12.345).run(conn, callback);
 // Result passed to callback
 12.0
@@ -33,7 +33,7 @@ The `floor` command can also be chained after an expression.
 
 __Example:__ Return the floor of -12.345.
 
-```js
+```javascript
 r.expr(-12.345).floor().run(conn, callback);
 // Result passed to callback
 -13.0
@@ -41,6 +41,6 @@ r.expr(-12.345).floor().run(conn, callback);
 
 __Example:__ Return Iron Man's weight, rounded down with `floor`.
 
-```js
+```javascript
 r.table('superheroes').get('ironman')('weight').floor().run(conn, callback);
 ```

--- a/api/javascript/math-and-logic/ge.md
+++ b/api/javascript/math-and-logic/ge.md
@@ -26,19 +26,19 @@ Compare values, testing if the left-hand value is greater than or equal to the r
 
 __Example:__ Test if a player has scored 10 points or more.
 
-```js
+```javascript
 r.table('players').get(1)('score').ge(10).run(conn, callback);
 ```
 
 __Example:__ Test if variables are ordered from lowest to highest.
 
-```js
+```javascript
 var a = 10, b = 20, c = 15;
 r.ge(a, b, c).run(conn, callback);
 ```
 
 This is the equivalent of the following:
 
-```js
+```javascript
 r.ge(a, b).and(r.ge(b, c)).run(conn, callback);
 ```

--- a/api/javascript/math-and-logic/gt.md
+++ b/api/javascript/math-and-logic/gt.md
@@ -26,19 +26,19 @@ Compare values, testing if the left-hand value is greater than the right-hand.
 
 __Example:__ Test if a player has scored more than 10 points.
 
-```js
+```javascript
 r.table('players').get(1)('score').gt(10).run(conn, callback);
 ```
 
 __Example:__ Test if variables are ordered from lowest to highest, with no values being equal to one another.
 
-```js
+```javascript
 var a = 10, b = 20, c = 15;
 r.gt(a, b, c).run(conn, callback);
 ```
 
 This is the equivalent of the following:
 
-```js
+```javascript
 r.gt(a, b).and(r.gt(b, c)).run(conn, callback);
 ```

--- a/api/javascript/math-and-logic/le.md
+++ b/api/javascript/math-and-logic/le.md
@@ -26,19 +26,19 @@ Compare values, testing if the left-hand value is less than or equal to the righ
 
 __Example:__ Test if a player has scored 10 points or less.
 
-```js
+```javascript
 r.table('players').get(1)('score').le(10).run(conn, callback);
 ```
 
 __Example:__ Test if variables are ordered from highest to lowest.
 
-```js
+```javascript
 var a = 20, b = 10, c = 15;
 r.le(a, b, c).run(conn, callback);
 ```
 
 This is the equivalent of the following:
 
-```js
+```javascript
 r.le(a, b).and(r.le(b, c)).run(conn, callback);
 ```

--- a/api/javascript/math-and-logic/lt.md
+++ b/api/javascript/math-and-logic/lt.md
@@ -26,19 +26,19 @@ Compare values, testing if the left-hand value is less than the right-hand.
 
 __Example:__ Test if a player has scored less than 10 points.
 
-```js
+```javascript
 r.table('players').get(1)('score').lt(10).run(conn, callback);
 ```
 
 __Example:__ Test if variables are ordered from highest to lowest, with no values being equal to one another.
 
-```js
+```javascript
 var a = 20, b = 10,c = 15;
 r.lt(a, b, c).run(conn, callback);
 ```
 
 This is the equivalent of the following:
 
-```js
+```javascript
 r.lt(a, b).and(r.lt(b, c)).run(conn, callback);
 ```

--- a/api/javascript/math-and-logic/mod.md
+++ b/api/javascript/math-and-logic/mod.md
@@ -23,7 +23,7 @@ Find the remainder when dividing two numbers.
 
 __Example:__ It's as easy as 2 % 2 = 0.
 
-```js
+```javascript
 r.expr(2).mod(2).run(conn, callback)
 ```
 

--- a/api/javascript/math-and-logic/mul.md
+++ b/api/javascript/math-and-logic/mul.md
@@ -28,13 +28,13 @@ Multiply two numbers, or make a periodic array.
 
 __Example:__ It's as easy as 2 * 2 = 4.
 
-```js
+```javascript
 r.expr(2).mul(2).run(conn, callback)
 ```
 
 __Example:__ Arrays can be multiplied by numbers as well.
 
-```js
+```javascript
 r.expr(["This", "is", "the", "song", "that", "never", "ends."]).mul(100).run(conn, callback)
 ```
 

--- a/api/javascript/math-and-logic/ne.md
+++ b/api/javascript/math-and-logic/ne.md
@@ -24,12 +24,12 @@ Test if two or more values are not equal.
 
 __Example:__ See if a user's `role` field is not set to `administrator`. 
 
-```js
+```javascript
 r.table('users').get(1)('role').ne('administrator').run(conn, callback);
 ```
 
 __Example:__ See if three variables do not contain equal values.
 
-```js
+```javascript
 r.ne(a, b, c).run(conn, callback);
 ```

--- a/api/javascript/math-and-logic/not.md
+++ b/api/javascript/math-and-logic/not.md
@@ -26,7 +26,7 @@ Compute the logical inverse (not) of an expression.
 
 __Example:__ Not true is false.
 
-```js
+```javascript
 r(true).not().run(conn, callback)
 r.not(true).run(conn, callback)
 ```
@@ -35,7 +35,7 @@ These evaluate to `false`.
 
 __Example:__ Return all the users that do not have a "flag" field.
 
-```js
+```javascript
 r.table('users').filter(function(user) {
     return user.hasFields('flag').not()
 }).run(conn, callback)
@@ -43,7 +43,7 @@ r.table('users').filter(function(user) {
 
 __Example:__ As above, but prefix-style.
 
-```js
+```javascript
 r.table('users').filter(function(user) {
     return r.not(user.hasFields('flag'))
 }).run(conn, callback)

--- a/api/javascript/math-and-logic/or.md
+++ b/api/javascript/math-and-logic/or.md
@@ -29,7 +29,7 @@ Calling `or` with zero arguments will return `false`.
 
 __Example:__ Return whether either `a` or `b` evaluate to true.
 
-```js
+```javascript
 var a = true, b = false;
 r.expr(a).or(b).run(conn, callback);
 // result passed to callback
@@ -38,7 +38,7 @@ true
 
 __Example:__ Return whether any of `x`, `y` or `z` evaluate to true.
 
-```js
+```javascript
 var x = false, y = false, z = false;
 r.or(x, y, z).run(conn, callback);
 // result passed to callback
@@ -47,7 +47,7 @@ false
 
 __Note:__ When using `or` inside a `filter` predicate to test the values of fields that may not exist on the documents being tested, you should use the `default` command with those fields so they explicitly return `false`.
 
-```js
+```javascript
 r.table('posts').filter(
     r.row('category').default('foo').eq('article').
     or(r.row('genre').default('foo').eq('mystery'))

--- a/api/javascript/math-and-logic/random.md
+++ b/api/javascript/math-and-logic/random.md
@@ -30,14 +30,14 @@ Note: The last argument given will always be the 'open' side of the range, but w
 
 __Example:__ Generate a random number in the range `[0,1)`
 
-```js
+```javascript
 r.random().run(conn, callback)
 ```
 
 
 __Example:__ Generate a random integer in the range `[0,100)`
 
-```js
+```javascript
 r.random(100).run(conn, callback)
 r.random(0, 100).run(conn, callback)
 ```
@@ -45,7 +45,7 @@ r.random(0, 100).run(conn, callback)
 
 __Example:__ Generate a random number in the range `(-2.24,1.59]`
 
-```js
+```javascript
 r.random(1.59, -2.24, {float: true}).run(conn, callback)
 ```
 

--- a/api/javascript/math-and-logic/round.md
+++ b/api/javascript/math-and-logic/round.md
@@ -28,7 +28,7 @@ For example, values of 1.0 up to but not including 1.5 will return 1.0, similar 
 
 __Example:__ Round 12.345 to the nearest integer.
 
-```js
+```javascript
 r.round(12.345).run(conn, callback);
 // Result passed to callback
 12.0
@@ -38,7 +38,7 @@ The `round` command can also be chained after an expression.
 
 __Example:__ Round -12.345 to the nearest integer.
 
-```js
+```javascript
 r.expr(-12.345).round().run(conn, callback);
 // Result passed to callback
 -12.0
@@ -46,6 +46,6 @@ r.expr(-12.345).round().run(conn, callback);
 
 __Example:__ Return Iron Man's weight, rounded to the nearest integer.
 
-```js
+```javascript
 r.table('superheroes').get('ironman')('weight').round().run(conn, callback);
 ```

--- a/api/javascript/math-and-logic/sub.md
+++ b/api/javascript/math-and-logic/sub.md
@@ -31,18 +31,18 @@ Subtract two numbers.
 
 __Example:__ It's as easy as 2 - 2 = 0.
 
-```js
+```javascript
 r.expr(2).sub(2).run(conn, callback)
 ```
 
 __Example:__ Create a date one year ago today.
 
-```js
+```javascript
 r.now().sub(365*24*60*60)
 ```
 
 __Example:__ Retrieve how many seconds elapsed between today and `date`.
 
-```js
+```javascript
 r.now().sub(date)
 ```

--- a/api/javascript/selecting-data/between.md
+++ b/api/javascript/selecting-data/between.md
@@ -29,7 +29,9 @@ You may also use the special constants `r.minval` and `r.maxval` for boundaries,
 
 If you use arrays as indexes (compound indexes), they will be sorted using [lexicographical order][lo]. Take the following range as an example:
 
-	[[1, "c"] ... [5, "e"]]
+```text
+[[1, "c"] ... [5, "e"]]
+```
 
 This range includes all compound keys:
 
@@ -41,44 +43,44 @@ This range includes all compound keys:
 
 __Example:__ Find all users with primary key >= 10 and < 20 (a normal half-open interval).
 
-```js
+```javascript
 r.table('marvel').between(10, 20).run(conn, callback);
 ```
 
 __Example:__ Find all users with primary key >= 10 and <= 20 (an interval closed on both sides).
 
-```js
+```javascript
 r.table('marvel').between(10, 20, {rightBound: 'closed'}).run(conn, callback);
 ```
 
 __Example:__ Find all users with primary key < 20.
 
-```js
+```javascript
 r.table('marvel').between(r.minval, 20).run(conn, callback);
 ```
 
 __Example:__ Find all users with primary key > 10.
 
-```js
+```javascript
 r.table('marvel').between(10, r.maxval, {leftBound: 'open'}).run(conn, callback);
 ```
 
 __Example:__ Between can be used on secondary indexes too. Just pass an optional index argument giving the secondary index to query.
 
-```js
+```javascript
 r.table('dc').between('dark_knight', 'man_of_steel', {index: 'code_name'}).run(conn, callback);
 ```
 
 __Example:__ Get all users whose full name is between "John Smith" and "Wade Welles."
 
-```js
+```javascript
 r.table("users").between(["Smith", "John"], ["Welles", "Wade"],
   {index: "full_name"}).run(conn, callback);
 ```
 
 __Example:__ Get the top 10 ranked teams in order.
 
-```js
+```javascript
 r.table("teams").orderBy({index: "rank"}).between(1, 11).run(conn, callback);
 ```
 
@@ -86,7 +88,7 @@ __Note:__ When `between` is chained after [orderBy](/api/javascript/order_by), b
 
 __Example:__ Subscribe to a [changefeed](/docs/changefeeds/javascript) of teams ranked in the top 10.
 
-```js
+```javascript
 r.table("teams").between(1, 11, {index: "rank"}).changes().run(conn, callback);
 ```
 

--- a/api/javascript/selecting-data/db.md
+++ b/api/javascript/selecting-data/db.md
@@ -25,7 +25,7 @@ The `db` command is optional. If it is not present in a query, the query will ru
 
 __Example:__ Explicitly specify a database for a query.
 
-```js
+```javascript
 r.db('heroes').table('marvel').run(conn, callback)
 ```
 

--- a/api/javascript/selecting-data/filter.md
+++ b/api/javascript/selecting-data/filter.md
@@ -43,7 +43,7 @@ __Note:__ `filter` does not use secondary indexes. For retrieving documents via 
 __Example:__ Get all users who are 30 years old.
 
 
-```js
+```javascript
 r.table('users').filter({age: 30}).run(conn, callback);
 ```
 
@@ -53,13 +53,13 @@ The predicate `{age: 30}` selects documents in the `users` table with an `age` f
 
 While the `{field: value}` style of predicate is useful for exact matches, a more general way to write a predicate is to use the [row](/api/javascript/row) command with a comparison operator such as [eq](/api/javascript/eq) or [gt](/api/javascript/gt), or to use an anonymous function that returns `true` or `false`.
 
-```js
+```javascript
 r.table('users').filter(r.row("age").eq(30)).run(conn, callback);
 ```
 
 In this case, the predicate `r.row("age").eq(30)` returns `true` if the field `age` is equal to 30. You can write this predicate as an anonymous function instead:
 
-```js
+```javascript
 r.table('users').filter(function (user) {
     return user("age").eq(30);
 }).run(conn, callback);
@@ -71,14 +71,14 @@ Also, predicates must evaluate document fields. They cannot evaluate [secondary 
 
 __Example:__ Get all users who are more than 18 years old.
 
-```js
+```javascript
 r.table("users").filter(r.row("age").gt(18)).run(conn, callback)
 ```
 
 
 __Example:__ Get all users who are less than 18 years old and more than 13 years old.
 
-```js
+```javascript
 r.table("users").filter(
     r.row("age").lt(18).and(r.row("age").gt(13))
 ).run(conn, callback);
@@ -87,7 +87,7 @@ r.table("users").filter(
 
 __Example:__ Get all users who are more than 18 years old or have their parental consent.
 
-```js
+```javascript
 r.table("users").filter(
     r.row("age").ge(18).or(r.row("hasParentalConsent"))
 ).run(conn, callback);
@@ -98,7 +98,7 @@ r.table("users").filter(
 __Example:__ Retrieve all users who subscribed between January 1st, 2012
 (included) and January 1st, 2013 (excluded).
 
-```js
+```javascript
 r.table("users").filter(function (user) {
     return user("subscriptionDate").during(
         r.time(2012, 1, 1, 'Z'), r.time(2013, 1, 1, 'Z'));
@@ -107,7 +107,7 @@ r.table("users").filter(function (user) {
 
 __Example:__ Retrieve all users who have a gmail account (whose field `email` ends with `@gmail.com`).
 
-```js
+```javascript
 r.table("users").filter(function (user) {
     return user("email").match("@gmail.com$");
 }).run(conn, callback);
@@ -117,7 +117,7 @@ __Example:__ Filter based on the presence of a value in an array.
 
 Given this schema for the `users` table:
 
-```js
+```javascript
 {
     name: String
     placesVisited: [String]
@@ -126,7 +126,7 @@ Given this schema for the `users` table:
 
 Retrieve all users whose field `placesVisited` contains `France`.
 
-```js
+```javascript
 r.table("users").filter(function(user) {
     return user("placesVisited").contains("France")
 }).run( conn, callback)
@@ -136,7 +136,7 @@ __Example:__ Filter based on nested fields.
 
 Given this schema for the `users` table:
 
-```js
+```javascript
 {
     id: String
     name: {
@@ -151,7 +151,7 @@ Retrieve all users named "William Adama" (first name "William", last name
 "Adama"), with any middle name.
 
 
-```js
+```javascript
 r.table("users").filter({
     name: {
         first: "William",
@@ -165,7 +165,7 @@ If you want an exact match for a field that is an object, you will have to use `
 Retrieve all users named "William Adama" (first name "William", last name
 "Adama"), and who do not have a middle name.
 
-```js
+```javascript
 r.table("users").filter(r.literal({
     name: {
         first: "William",
@@ -176,7 +176,7 @@ r.table("users").filter(r.literal({
 
 You may rewrite these with anonymous functions.
 
-```js
+```javascript
 r.table("users").filter(function(user) {
     return user("name")("first").eq("William")
         .and(user("name")("last").eq("Adama"));
@@ -196,7 +196,7 @@ By default, documents missing fields tested by the `filter` predicate are skippe
 
 __Example:__ Get all users less than 18 years old or whose `age` field is missing.
 
-```js
+```javascript
 r.table("users").filter(
     r.row("age").lt(18), {default: true}
 ).run(conn, callback);
@@ -205,7 +205,7 @@ r.table("users").filter(
 __Example:__ Get all users more than 18 years old. Throw an error if a
 document is missing the field `age`.
 
-```js
+```javascript
 r.table("users").filter(
     r.row("age").gt(18), {default: r.error()}
 ).run(conn, callback);
@@ -213,7 +213,7 @@ r.table("users").filter(
 
 __Example:__ Get all users who have given their phone number (all the documents whose field `phoneNumber` exists and is not `null`).
 
-```js
+```javascript
 r.table('users').filter(function (user) {
     return user.hasFields('phoneNumber');
 }).run(conn, callback);
@@ -221,7 +221,7 @@ r.table('users').filter(function (user) {
 
 __Example:__ Get all users with an "editor" role or an "admin" privilege.
 
-```js
+```javascript
 r.table('users').filter(function (user) {
     return (user('role').eq('editor').default(false).
         or(user('privilege').eq('admin').default(false)));

--- a/api/javascript/selecting-data/get.md
+++ b/api/javascript/selecting-data/get.md
@@ -25,13 +25,13 @@ If no document exists with that primary key, `get` will return `null`.
 
 __Example:__ Find a document by UUID.
 
-```js
+```javascript
 r.table('posts').get('a9849eef-7176-4411-935b-79a6e3c56a74').run(conn, callback);
 ```
 
 __Example:__ Find a document and merge another document with it.
 
-```js
+```javascript
 r.table('heroes').get(3).merge(
     { powers: ['invisibility', 'speed'] }
 ).run(conn, callback);
@@ -39,6 +39,6 @@ r.table('heroes').get(3).merge(
 
 ___Example:__ Subscribe to a document's [changefeed](/docs/changefeeds/javascript).
 
-```js
+```javascript
 r.table('heroes').get(3).changes().run(conn, callback);
 ```

--- a/api/javascript/selecting-data/get_all.md
+++ b/api/javascript/selecting-data/get_all.md
@@ -25,19 +25,19 @@ Get all documents where the given value matches the value of the requested index
 
 __Example:__ Secondary index keys are not guaranteed to be unique so we cannot query via [get](/api/javascript/get/) when using a secondary index.
 
-```js
+```javascript
 r.table('marvel').getAll('man_of_steel', {index:'code_name'}).run(conn, callback)
 ```
 
 __Example:__ Without an index argument, we default to the primary index. While `get` will either return the document or `null` when no document with such a primary key value exists, this will return either a one or zero length stream.
 
-```js
+```javascript
 r.table('dc').getAll('superman').run(conn, callback)
 ```
 
 __Example:__ You can get multiple documents in a single call to `get_all`.
 
-```js
+```javascript
 r.table('dc').getAll('superman', 'ant man').run(conn, callback)
 ```
 
@@ -47,7 +47,7 @@ __Note:__ `getAll` does not perform any de-duplication. If you pass the same key
 
 __Example:__ You can use [args](/api/javascript/args/) with `getAll` to retrieve multiple documents whose keys are in a list. This uses `getAll` to get a list of female superheroes, coerces that to an array, and then gets a list of villains who have those superheroes as enemies.
 
-```js
+```javascript
 r.do(
     r.table('heroes').getAll('f', {index: 'gender'})('id').coerceTo('array'),
     function(heroines) {

--- a/api/javascript/selecting-data/table.md
+++ b/api/javascript/selecting-data/table.md
@@ -23,13 +23,13 @@ Return all documents in a table. Other commands may be chained after `table` to 
 
 __Example:__ Return all documents in the table 'marvel' of the default database.
 
-```js
+```javascript
 r.table('marvel').run(conn, callback)
 ```
 
 __Example:__ Return all documents in the table 'marvel' of the database 'heroes'.
 
-```js
+```javascript
 r.db('heroes').table('marvel').run(conn, callback)
 ```
 
@@ -43,6 +43,6 @@ There are two optional arguments.
 
 __Example:__ Allow potentially out-of-date data in exchange for faster reads.
 
-```js
+```javascript
 r.db('heroes').table('marvel', {readMode: 'outdated'}).run(conn, callback)
 ```

--- a/api/javascript/string-manipulation/downcase.md
+++ b/api/javascript/string-manipulation/downcase.md
@@ -24,13 +24,13 @@ Lowercases a string.
 
 __Example:__
 
-```js
+```javascript
 r.expr("Sentence about LaTeX.").downcase().run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 "sentence about latex."
 ```
 

--- a/api/javascript/string-manipulation/match.md
+++ b/api/javascript/string-manipulation/match.md
@@ -39,7 +39,7 @@ __Example:__ Get all users whose name starts with "A". Because `null` evaluates 
 [filter](/api/javascript/filter/), you can just use the result of `match` for the predicate.
 
 
-```js
+```javascript
 r.table('users').filter(function(doc){
     return doc('name').match("^A")
 }).run(conn, callback)
@@ -47,14 +47,14 @@ r.table('users').filter(function(doc){
 
 __Example:__ Get all users whose name ends with "n".
 
-```js
+```javascript
 r.table('users').filter(function(doc){
     return doc('name').match("n$")
 }).run(conn, callback)
 ```
 __Example:__ Get all users whose name has "li" in it
 
-```js
+```javascript
 r.table('users').filter(function(doc){
     return doc('name').match("li")
 }).run(conn, callback)
@@ -62,7 +62,7 @@ r.table('users').filter(function(doc){
 
 __Example:__ Get all users whose name is "John" with a case-insensitive search.
 
-```js
+```javascript
 r.table('users').filter(function(doc){
     return doc('name').match("(?i)^john$")
 }).run(conn, callback)
@@ -70,7 +70,7 @@ r.table('users').filter(function(doc){
 
 __Example:__ Get all users whose name is composed of only characters between "a" and "z".
 
-```js
+```javascript
 r.table('users').filter(function(doc){
     return doc('name').match("(?i)^[a-z]+$")
 }).run(conn, callback)
@@ -78,7 +78,7 @@ r.table('users').filter(function(doc){
 
 __Example:__ Get all users where the zipcode is a string of 5 digits.
 
-```js
+```javascript
 r.table('users').filter(function(doc){
     return doc('zipcode').match("\\d{5}")
 }).run(conn, callback)
@@ -87,13 +87,13 @@ r.table('users').filter(function(doc){
 
 __Example:__ Retrieve the domain of a basic email
 
-```js
+```javascript
 r.expr("name@domain.com").match(".*@(.*)").run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 {
     start: 0,
     end: 20,
@@ -110,7 +110,7 @@ Result:
 
 You can then retrieve only the domain with the [\(\)](/api/javascript/get_field) selector and [nth](/api/javascript/nth).
 
-```js
+```javascript
 r.expr("name@domain.com").match(".*@(.*)")("groups").nth(0)("str").run(conn, callback)
 ```
 
@@ -119,6 +119,6 @@ Returns `'domain.com'`
 
 __Example:__ Fail to parse out the domain and returns `null`.
 
-```js
+```javascript
 r.expr("name[at]domain.com").match(".*@(.*)").run(conn, callback)
 ```

--- a/api/javascript/string-manipulation/split.md
+++ b/api/javascript/string-manipulation/split.md
@@ -35,61 +35,61 @@ single-character strings.
 
 __Example:__ Split on whitespace.
 
-```js
+```javascript
 r.expr("foo  bar bax").split().run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 ["foo", "bar", "bax"]
 ```
 
 __Example:__ Split the entries in a CSV file.
 
-```js
+```javascript
 r.expr("12,37,,22,").split(",").run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 ["12", "37", "", "22", ""]
 ```
 
 __Example:__ Split a string into characters.
 
-```js
+```javascript
 r.expr("mlucy").split("").run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 ["m", "l", "u", "c", "y"]
 ```
 
 __Example:__ Split the entries in a CSV file, but only at most 3
 times.
 
-```js
+```javascript
 r.expr("12,37,,22,").split(",", 3).run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 ["12", "37", "", "22,"]
 ```
 
 __Example:__ Split on whitespace at most once (i.e. get the first word).
 
-```js
+```javascript
 r.expr("foo  bar bax").split(null, 1).run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 ["foo", "bar bax"]
 ```

--- a/api/javascript/string-manipulation/upcase.md
+++ b/api/javascript/string-manipulation/upcase.md
@@ -24,13 +24,13 @@ Uppercases a string.
 
 __Example:__
 
-```js
+```javascript
 r.expr("Sentence about LaTeX.").upcase().run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 "SENTENCE ABOUT LATEX."
 ```
 

--- a/api/javascript/transformations/concat_map.md
+++ b/api/javascript/transformations/concat_map.md
@@ -25,25 +25,25 @@ Concatenate one or more elements into a single sequence using a mapping function
 
 `concatMap` works in a similar fashion to [map](/api/javascript/map/), applying the given function to each element in a sequence, but it will always return a single sequence. If the mapping function returns a sequence, `map` would produce a sequence of sequences:
 
-```js
+```javascript
 r.expr([1, 2, 3]).map(function(x) { return [x, x.mul(2)] }).run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 [[1, 2], [2, 4], [3, 6]]
 ```
 
 Whereas `concatMap` with the same mapping function would merge those sequences into one:
 
-```js
+```javascript
 r.expr([1, 2, 3]).concatMap(function(x) { return [x, x.mul(2)] }).run(conn, callback)
 ```
 
 Result:
 
-```js
+```javascript
 [1, 2, 2, 4, 3, 6]
 ```
 
@@ -51,7 +51,7 @@ The return value, array or stream, will be the same type as the input.
 
 __Example:__ Construct a sequence of all monsters defeated by Marvel heroes. The field "defeatedMonsters" is an array of one or more monster names.
 
-```js
+```javascript
 r.table('marvel').concatMap(function(hero) {
     return hero('defeatedMonsters')
 }).run(conn, callback)
@@ -59,7 +59,7 @@ r.table('marvel').concatMap(function(hero) {
 
 __Example:__ Simulate an [eqJoin](/api/javascript/eq_join/) using `concatMap`. (This is how ReQL joins are implemented internally.)
 
-```js
+```javascript
 r.table("posts").concatMap(function(post) {
 	return r.table("comments").getAll(
 		post("id"),

--- a/api/javascript/transformations/is_empty.md
+++ b/api/javascript/transformations/is_empty.md
@@ -22,6 +22,6 @@ Test if a sequence is empty.
 
 __Example:__ Are there any documents in the marvel table?
 
-```js
+```javascript
 r.table('marvel').isEmpty().run(conn, callback)
 ```

--- a/api/javascript/transformations/limit.md
+++ b/api/javascript/transformations/limit.md
@@ -28,7 +28,7 @@ End the sequence after the given number of elements.
 
 __Example:__ Only so many can fit in our Pantheon of heroes.
 
-```js
+```javascript
 r.table('marvel').orderBy('belovedness').limit(10).run(conn, callback)
 ```
 

--- a/api/javascript/transformations/map.md
+++ b/api/javascript/transformations/map.md
@@ -31,7 +31,7 @@ Note that `map` can only be applied to sequences, not single values. If you wish
 
 __Example:__ Return the first five squares.
 
-```js
+```javascript
 r.expr([1, 2, 3, 4, 5]).map(function (val) {
     return val.mul(val);
 }).run(conn, callback);
@@ -41,7 +41,7 @@ r.expr([1, 2, 3, 4, 5]).map(function (val) {
 
 __Example:__ Sum the elements of three sequences.
 
-```js
+```javascript
 var sequence1 = [100, 200, 300, 400];
 var sequence2 = [10, 20, 30, 40];
 var sequence3 = [1, 2, 3, 4];
@@ -56,7 +56,7 @@ __Example:__ Rename a field when retrieving documents using `map` and [merge](/a
 
 This example renames the field `id` to `userId` when retrieving documents from the table `users`.
 
-```js
+```javascript
 r.table('users').map(function (doc) {
     return doc.merge({userId: doc('id')}).without('id');
 }).run(conn, callback);
@@ -64,7 +64,7 @@ r.table('users').map(function (doc) {
 
 Note that in this case, [row](/api/javascript/row) may be used as an alternative to writing an anonymous function, as it returns the same value as the function parameter receives:
 
-```js
+```javascript
 r.table('users').map(
     r.row.merge({userId: r.row('id')}).without('id');
 }).run(conn, callback);
@@ -73,7 +73,7 @@ r.table('users').map(
 
 __Example:__ Assign every superhero an archenemy.
 
-```js
+```javascript
 r.table('heroes').map(r.table('villains'), function (hero, villain) {
     return hero.merge({villain: villain});
 }).run(conn, callback);

--- a/api/javascript/transformations/nth.md
+++ b/api/javascript/transformations/nth.md
@@ -26,19 +26,19 @@ Get the *nth* element of a sequence, counting from zero. If the argument is nega
 
 __Example:__ Select the second element in the array.
 
-```js
+```javascript
 r.expr([1,2,3]).nth(1).run(conn, callback)
 r.expr([1,2,3])(1).run(conn, callback)
 ```
 
 __Example:__ Select the bronze medalist from the competitors.
 
-```js
+```javascript
 r.table('players').orderBy({index: r.desc('score')}).nth(3).run(conn, callback)
 ```
 
 __Example:__ Select the last place competitor.
 
-```js
+```javascript
 r.table('players').orderBy({index: r.desc('score')}).nth(-1).run(conn, callback)
 ```

--- a/api/javascript/transformations/offsets_of.md
+++ b/api/javascript/transformations/offsets_of.md
@@ -21,13 +21,13 @@ Get the indexes of an element in a sequence. If the argument is a predicate, get
 
 __Example:__ Find the position of the letter 'c'.
 
-```js
+```javascript
 r.expr(['a','b','c']).offsetsOf('c').run(conn, callback)
 ```
 
 __Example:__ Find the popularity ranking of invisible heroes.
 
-```js
+```javascript
 r.table('marvel').union(r.table('dc')).orderBy('popularity').offsetsOf(
     r.row('superpowers').contains('invisibility')
 ).run(conn, callback)

--- a/api/javascript/transformations/order_by.md
+++ b/api/javascript/transformations/order_by.md
@@ -44,7 +44,7 @@ Sorting functions passed to `orderBy` must be deterministic. You cannot, for ins
 
 __Example:__ Order all the posts using the index `date`.   
 
-```js
+```javascript
 r.table('posts').orderBy({index: 'date'}).run(conn, callback);
 ```
 
@@ -52,32 +52,32 @@ r.table('posts').orderBy({index: 'date'}).run(conn, callback);
 
 The index must either be the primary key or have been previously created with [indexCreate](/api/javascript/index_create/).
 
-```js
+```javascript
 r.table('posts').indexCreate('date').run(conn, callback);
 ```
 
 You can also select a descending ordering:
 
-```js
+```javascript
 r.table('posts').orderBy({index: r.desc('date')}).run(conn, callback);
 ```
 
 __Example:__ Order a sequence without an index.
 
-```js
+```javascript
 r.table('posts').get(1)('comments').orderBy('date').run(conn, callback);
 ```
 
 You can also select a descending ordering:
 
-```js
+```javascript
 r.table('posts').get(1)('comments').orderBy(r.desc('date')).run(conn, callback);
 ```
 
 If you're doing ad-hoc analysis and know your table won't have more then 100,000
 elements (or you've changed the setting of the `array_limit` option for [run](/api/javascript/run)) you can run `orderBy` without an index:
 
-```js
+```javascript
 r.table('small_table').orderBy('date').run(conn, callback);
 ```
 
@@ -86,13 +86,13 @@ __Example:__ You can efficiently order using multiple fields by using a
 
 Order by date and title.
 
-```js
+```javascript
 r.table('posts').orderBy({index: 'dateAndTitle'}).run(conn, callback);
 ```
 
 The index must either be the primary key or have been previously created with [indexCreate](/api/javascript/index_create/).
 
-```js
+```javascript
 r.table('posts').indexCreate('dateAndTitle', [r.row('date'), r.row('title')]).run(conn, callback);
 ```
 
@@ -102,7 +102,7 @@ to track progress.
 __Example:__ If you have a sequence with fewer documents than the `arrayLimit`, you can order it
 by multiple fields without an index.
 
-```js
+```javascript
 r.table('small_table').orderBy('date', r.desc('title')).run(conn, callback);
 ```
 
@@ -110,25 +110,25 @@ __Example:__ Notice that an index ordering always has highest
 precedence. The following query orders posts by date, and if multiple
 posts were published on the same date, they will be ordered by title.
 
-```js
+```javascript
 r.table('post').orderBy('title', {index: 'date'}).run(conn, callback);
 ```
 
 __Example:__ Use [nested field](/docs/cookbook/javascript/#filtering-based-on-nested-fields) syntax to sort on fields from subdocuments. (You can also create indexes on nested fields using this syntax with `indexCreate`.)
 
-```js
+```javascript
 r.table('user').orderBy(r.row('group')('id')).run(conn, callback);
 ```
 
 __Example:__ You can efficiently order data on arbitrary expressions using indexes.
 
-```js
+```javascript
 r.table('posts').orderBy({index: 'votes'}).run(conn, callback);
 ```
 
 The index must have been previously created with [indexCreate](/api/javascript/index_create/).
 
-```js
+```javascript
 r.table('posts').indexCreate('votes', function(post) {
     return post('upvotes').sub(post('downvotes'))
 }).run(conn, callback);
@@ -136,7 +136,7 @@ r.table('posts').indexCreate('votes', function(post) {
 
 __Example:__ If you have a sequence with fewer documents than the `arrayLimit`, you can order it with an arbitrary function directly.
 
-```js
+```javascript
 r.table('small_table').orderBy(function(doc) {
     return doc('upvotes').sub(doc('downvotes'))
 }).run(conn, callback);
@@ -144,7 +144,7 @@ r.table('small_table').orderBy(function(doc) {
 
 You can also select a descending ordering:
 
-```js
+```javascript
 r.table('small_table').orderBy(r.desc(function(doc) {
     return doc('upvotes').sub(doc('downvotes'))
 })).run(conn, callback);
@@ -152,7 +152,7 @@ r.table('small_table').orderBy(r.desc(function(doc) {
 
 __Example:__ Ordering after a `between` command can be done as long as the same index is being used.
 
-```js
+```javascript
 r.table('posts').between(r.time(2013, 1, 1, '+00:00'), r.time(2013, 1, 1, '+00:00'), {index: 'date'})
     .orderBy({index: 'date'}).run(conn, callback);
 ```

--- a/api/javascript/transformations/sample.md
+++ b/api/javascript/transformations/sample.md
@@ -28,6 +28,6 @@ If the sequence has less than the requested number of elements (i.e., calling `s
 
 __Example:__ Select 3 random heroes.
 
-```js
+```javascript
 r.table('marvel').sample(3).run(conn, callback)
 ```

--- a/api/javascript/transformations/skip.md
+++ b/api/javascript/transformations/skip.md
@@ -27,6 +27,6 @@ Skip a number of elements from the head of the sequence.
 
 __Example:__ Here in conjunction with [orderBy](/api/javascript/order_by/) we choose to ignore the most successful heroes.
 
-```js
+```javascript
 r.table('marvel').orderBy('successMetric').skip(10).run(conn, callback)
 ```

--- a/api/javascript/transformations/slice.md
+++ b/api/javascript/transformations/slice.md
@@ -45,25 +45,25 @@ With a string, `slice` behaves similarly, with the indexes referring to Unicode 
 
 __Example:__ Return the fourth, fifth and sixth youngest players. (The youngest player is at index 0, so those are elements 3&ndash;5.)
 
-```js
+```javascript
 r.table('players').orderBy({index: 'age'}).slice(3,6).run(conn, callback);
 ```
 
 __Example:__ Return all but the top three players who have a red flag.
 
-```js
+```javascript
 r.table('players').filter({flag: 'red'}).orderBy(r.desc('score')).slice(3).run(conn, callback);
 ```
 
 __Example:__ Return holders of tickets `X` through `Y`, assuming tickets are numbered sequentially. We want to include ticket `Y`.
 
-```js
+```javascript
 r.table('users').orderBy('ticket').slice(x, y, {right_bound: 'closed'}).run(conn, callback);
 ```
 
 __Example:__ Return the elements of an array from the second through two from the end (that is, not including the last two).
 
-```js
+```javascript
 r.expr([0,1,2,3,4,5]).slice(2,-2).run(conn, callback);
 // Result passed to callback
 [2,3]
@@ -71,7 +71,7 @@ r.expr([0,1,2,3,4,5]).slice(2,-2).run(conn, callback);
 
 __Example:__ Return the third through fifth characters of a string.
 
-```js
+```javascript
 r.expr("rutabaga").slice(2,5).run(conn, callback);
 // Result passed to callback
 "tab"

--- a/api/javascript/transformations/union.md
+++ b/api/javascript/transformations/union.md
@@ -30,13 +30,13 @@ The optional `interleave` argument controls how the sequences will be merged:
 
 __Example:__ Construct a stream of all heroes.
 
-```js
+```javascript
 r.table('marvel').union(r.table('dc')).run(conn, callback);
 ```
 
 __Example:__ Combine four arrays into one.
 
-```js
+```javascript
 r.expr([1, 2]).union([3, 4], [5, 6], [7, 8, 9]).run(conn, callback)
 // Result passed to callback
 [1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -44,7 +44,7 @@ r.expr([1, 2]).union([3, 4], [5, 6], [7, 8, 9]).run(conn, callback)
 
 __Example:__ Create a [changefeed][cf] from the first example.
 
-```js
+```javascript
 r.table('marvel').union(r.table('dc')).changes().run(conn, callback);
 ```
 
@@ -54,7 +54,7 @@ Now, when any heroes are added, modified or deleted from either table, a change 
 
 __Example:__ Merge-sort the tables of heroes, ordered by name.
 
-```js
+```javascript
 r.table('marvel').order_by('name').union(
     r.table('dc').order_by('name'), {interleave: 'name'}
 ).run(conn, callback);

--- a/api/javascript/transformations/with_fields.md
+++ b/api/javascript/transformations/with_fields.md
@@ -28,7 +28,7 @@ __Example:__ Get a list of users and their posts, excluding any users who have n
 
 Existing table structure:
 
-```js
+```javascript
 [
     { 'id': 1, 'user': 'bob', 'email': 'bob@foo.com', 'posts': [ 1, 4, 5 ] },
     { 'id': 2, 'user': 'george', 'email': 'george@foo.com' },
@@ -38,7 +38,7 @@ Existing table structure:
 
 Command and output:
 
-```js
+```javascript
 > r.table('users').withFields('id', 'user', 'posts').run(conn, callback)
 // Result passed to callback
 [
@@ -49,6 +49,6 @@ Command and output:
 
 __Example:__ Use the [nested field syntax](/docs/nested-fields/) to get a list of users with cell phone numbers in their contacts.
 
-```js
+```javascript
 r.table('users').withFields('id', 'user', {contact: {phone: "work"}).run(conn, callback)
 ```

--- a/api/javascript/writing-data/delete.md
+++ b/api/javascript/writing-data/delete.md
@@ -62,34 +62,34 @@ RethinkDB write operations will only throw exceptions if errors occur before any
 
 __Example:__ Delete a single document from the table `comments`.
 
-```js
+```javascript
 r.table("comments").get("7eab9e63-73f1-4f33-8ce4-95cbea626f59").delete().run(conn, callback)
 ```
 
 
 __Example:__ Delete all documents from the table `comments`.
 
-```js
+```javascript
 r.table("comments").delete().run(conn, callback)
 ```
 
 
 __Example:__ Delete all comments where the field `idPost` is `3`.
 
-```js
+```javascript
 r.table("comments").filter({idPost: 3}).delete().run(conn, callback)
 ```
 
 
 __Example:__ Delete a single document from the table `comments` and return its value.
 
-```js
+```javascript
 r.table("comments").get("7eab9e63-73f1-4f33-8ce4-95cbea626f59").delete({returnChanges: true}).run(conn, callback)
 ```
 
 The result look like:
 
-```js
+```javascript
 {
     deleted: 1,
     errors: 0,
@@ -115,6 +115,6 @@ The result look like:
 __Example:__ Delete all documents from the table `comments` without waiting for the
 operation to be flushed to disk.
 
-```js
+```javascript
 r.table("comments").delete({durability: "soft"}).run(conn, callback)
 ```

--- a/api/javascript/writing-data/insert.md
+++ b/api/javascript/writing-data/insert.md
@@ -62,7 +62,7 @@ RethinkDB write operations will only throw exceptions if errors occur before any
 
 __Example:__ Insert a document into the table `posts`.
 
-```js
+```javascript
 r.table("posts").insert({
     id: 1,
     title: "Lorem ipsum",
@@ -74,7 +74,7 @@ r.table("posts").insert({
 
 The result will be:
 
-```js
+```javascript
 {
     deleted: 0,
     errors: 0,
@@ -89,7 +89,7 @@ The result will be:
 __Example:__ Insert a document without a defined primary key into the table `posts` where the
 primary key is `id`.
 
-```js
+```javascript
 r.table("posts").insert({
     title: "Lorem ipsum",
     content: "Dolor sit amet"
@@ -98,7 +98,7 @@ r.table("posts").insert({
 
 RethinkDB will generate a primary key and return it in `generated_keys`.
 
-```js
+```javascript
 {
     deleted: 0,
     errors: 0,
@@ -114,13 +114,13 @@ RethinkDB will generate a primary key and return it in `generated_keys`.
 
 Retrieve the document you just inserted with:
 
-```js
+```javascript
 r.table("posts").get("dd782b64-70a7-43e4-b65e-dd14ae61d947").run(conn, callback)
 ```
 
 And you will get back:
 
-```js
+```javascript
 {
     id: "dd782b64-70a7-43e4-b65e-dd14ae61d947",
     title: "Lorem ipsum",
@@ -131,7 +131,7 @@ And you will get back:
 
 __Example:__ Insert multiple documents into the table `users`.
 
-```js
+```javascript
 r.table("users").insert([
     {id: "william", email: "william@rethinkdb.com"},
     {id: "lara", email: "lara@rethinkdb.com"}
@@ -141,7 +141,7 @@ r.table("users").insert([
 
 __Example:__ Insert a document into the table `users`, replacing the document if it already exists.  
 
-```js
+```javascript
 r.table("users").insert(
     {id: "william", email: "william@rethinkdb.com"},
     {conflict: "replace"}
@@ -150,14 +150,14 @@ r.table("users").insert(
 
 __Example:__ Copy the documents from `posts` to `postsBackup`.
 
-```js
+```javascript
 r.table("postsBackup").insert(r.table("posts")).run(conn, callback)
 ```
 
 
 __Example:__ Get back a copy of the inserted document (with its generated primary key).
 
-```js
+```javascript
 r.table("posts").insert(
     {title: "Lorem ipsum", content: "Dolor sit amet"},
     {returnChanges: true}
@@ -166,7 +166,7 @@ r.table("posts").insert(
 
 The result will be
 
-```js
+```javascript
 {
     deleted: 0,
     errors: 0,
@@ -192,7 +192,7 @@ The result will be
 
 __Example:__ Provide a resolution function that concatenates memo content in case of conflict.
 
-```js
+```javascript
 // assume newMemos is a list of memo documents to insert
 r.table('memos').insert(newMemos, {conflict: function(id, oldDoc, newDoc) {
     return newDoc.merge(

--- a/api/javascript/writing-data/replace.md
+++ b/api/javascript/writing-data/replace.md
@@ -81,7 +81,7 @@ RethinkDB write operations will only throw exceptions if errors occur before any
 
 __Example:__ Replace the document with the primary key `1`.
 
-```js
+```javascript
 r.table("posts").get(1).replace({
     id: 1,
     title: "Lorem ipsum",
@@ -92,7 +92,7 @@ r.table("posts").get(1).replace({
 
 __Example:__ Remove the field `status` from all posts.
 
-```js
+```javascript
 r.table("posts").replace(function(post) {
     return post.without("status")
 }).run(conn, callback)
@@ -100,7 +100,7 @@ r.table("posts").replace(function(post) {
 
 __Example:__ Remove all the fields that are not `id`, `title` or `content`.
 
-```js
+```javascript
 r.table("posts").replace(function(post) {
     return post.pluck("id", "title", "content")
 }).run(conn, callback)
@@ -108,7 +108,7 @@ r.table("posts").replace(function(post) {
 
 __Example:__ Replace the document with the primary key `1` using soft durability.
 
-```js
+```javascript
 r.table("posts").get(1).replace({
     id: 1,
     title: "Lorem ipsum",
@@ -122,7 +122,7 @@ r.table("posts").get(1).replace({
 __Example:__ Replace the document with the primary key `1` and return the values of the document before
 and after the replace operation.
 
-```js
+```javascript
 r.table("posts").get(1).replace({
     id: 1,
     title: "Lorem ipsum",
@@ -135,7 +135,7 @@ r.table("posts").get(1).replace({
 
 The result will have two fields `old_val` and `new_val`.
 
-```js
+```javascript
 {
     deleted: 0,
     errors: 0,

--- a/api/javascript/writing-data/sync.md
+++ b/api/javascript/writing-data/sync.md
@@ -28,7 +28,7 @@ If successful, the operation returns an object: `{synced: 1}`.
 __Example:__ After having updated multiple heroes with soft durability, we now want to wait
 until these changes are persisted.
 
-```js
+```javascript
 r.table('marvel').sync().run(conn, callback)
 ```
 

--- a/api/javascript/writing-data/update.md
+++ b/api/javascript/writing-data/update.md
@@ -57,19 +57,19 @@ RethinkDB write operations will only throw exceptions if errors occur before any
 
 __Example:__ Update the status of the post with `id` of `1` to `published`.
 
-```js
+```javascript
 r.table("posts").get(1).update({status: "published"}).run(conn, callback)
 ```
 
 __Example:__ Update the status of all posts to `published`.
 
-```js
+```javascript
 r.table("posts").update({status: "published"}).run(conn, callback)
 ```
 
 __Example:__ Update the status of all the posts written by William.
 
-```js
+```javascript
 r.table("posts").filter({author: "William"}).update({status: "published"}).run(conn, callback)
 ```
 
@@ -80,7 +80,7 @@ Note that `filter`, `getAll` and similar operations do _not_ execute in an atomi
 __Example:__ Increment the field `view` of the post with `id` of `1`.
 This query will throw an error if the field `views` doesn't exist.
 
-```js
+```javascript
 r.table("posts").get(1).update({
     views: r.row("views").add(1)
 }).run(conn, callback)
@@ -89,7 +89,7 @@ r.table("posts").get(1).update({
 __Example:__ Increment the field `view` of the post with `id` of `1`.
 If the field `views` does not exist, it will be set to `0`.
 
-```js
+```javascript
 r.table("posts").get(1).update({
     views: r.row("views").add(1).default(0)
 }).run(conn, callback)
@@ -98,7 +98,7 @@ r.table("posts").get(1).update({
 __Example:__ Perform a conditional update.  
 If the post has more than 100 views, set the `type` of a post to `hot`, else set it to `normal`.
 
-```js
+```javascript
 r.table("posts").get(1).update(function(post) {
     return r.branch(
         post("views").gt(100),
@@ -110,7 +110,7 @@ r.table("posts").get(1).update(function(post) {
 
 __Example:__ Update the field `numComments` with the result of a sub-query. Because this update is not atomic, you must pass the `nonAtomic` flag.
 
-```js
+```javascript
 r.table("posts").get(1).update({
     numComments: r.table("comments").filter({idPost: 1}).count()
 }, {
@@ -120,13 +120,13 @@ r.table("posts").get(1).update({
 
 If you forget to specify the `nonAtomic` flag, you will get a `ReqlRuntimeError`:
 
-```
+```text
 ReqlRuntimeError: Could not prove function deterministic.  Maybe you want to use the non_atomic flag? 
 ```
 
 __Example:__ Update the field `numComments` with a random value between 0 and 100. This update cannot be proven deterministic because of `r.js` (and in fact is not), so you must pass the `nonAtomic` flag.
 
-```js
+```javascript
 r.table("posts").get(1).update({
     num_comments: r.js("Math.floor(Math.random()*100)")
 }, {
@@ -136,13 +136,13 @@ r.table("posts").get(1).update({
 
 __Example:__ Update the status of the post with `id` of `1` using soft durability.
 
-```js
+```javascript
 r.table("posts").get(1).update({status: "published"}, {durability: "soft"}).run(conn, callback)
 ```
 
 __Example:__ Increment the field `views` and return the values of the document before and after the update operation.
 
-```js
+```javascript
 r.table("posts").get(1).update({
     views: r.row("views").add(1)
 }, {
@@ -152,7 +152,7 @@ r.table("posts").get(1).update({
 
 The result will now include a `changes` field:
 
-```js
+```javascript
 {
     deleted: 0,
     errors: 0,
@@ -188,7 +188,7 @@ The `update` command supports RethinkDB's [nested field][nf] syntax to update su
 
 [nf]: /docs/nested-fields/javascript
 
-```js
+```javascript
 {
 	id: 10001,
 	name: "Bob Smith",
@@ -226,7 +226,7 @@ The `update` command supports RethinkDB's [nested field][nf] syntax to update su
 
 __Example:__ Update Bob Smith's cell phone number.
 
-```js
+```javascript
 r.table("users").get(10001).update(
     {contact: {phone: {cell: "408-555-4242"}}}
 ).run(conn, callback)
@@ -234,7 +234,7 @@ r.table("users").get(10001).update(
 
 __Example:__ Add another note to Bob Smith's record.
 
-```js
+```javascript
 var newNote = {
     date: r.now(),
     from: "Inigo Montoya",
@@ -249,7 +249,7 @@ This will fail if the `notes` field does not exist in the document. To perform t
 
 [default]: /api/javascript/default/
 
-```js
+```javascript
 r.table("users").get(10001).update(
     {notes: r.row("notes").default([]).append(newNote)}
 ).run(conn, callback)
@@ -257,7 +257,7 @@ r.table("users").get(10001).update(
 
 __Example:__ Send a note to every user with an ICQ number.
 
-```js
+```javascript
 var icqNote = {
     date: r.now(),
     from: "Admin",
@@ -274,7 +274,7 @@ __Example:__ Replace all of Bob's IM records. Normally, `update` will merge nest
 
 [literal]: /api/javascript/literal/
 
-```js
+```javascript
 r.table('users').get(10001).update(
     {contact: {im: r.literal({aim: "themoosemeister"})}}
 ).run(conn, callback)


### PR DESCRIPTION
This commit standardises the JavaScript code examples to make them
easier to parse using automated tools.

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

Using `javascript` instead of `js` makes it easier for parsers to differentiate the code blocks from `json` code blocks. This pull request also makes the `text` code blocks explicit. I'm generating a Rust driver from the JavaScript documentation, so I needed to make these changes.
