### PR TITLE
Standardise JavaScript code examples

### DIFF
--- a/api/javascript/administration/grant.md
+++ b/api/javascript/administration/grant.md
@@ -47,6 +47,7 @@ The `grant` command returns an object of the following form:
             "old_val": { original permissions }
         }
     ]
+}
 ```
 
 The `granted` field will always be `1`, and the `permissions_changes` list will have one object, describing the new permissions values and the old values they were changed from (which may be `null`).

--- a/api/javascript/aggregation/ungroup.md
+++ b/api/javascript/aggregation/ungroup.md
@@ -116,7 +116,7 @@ Result:
 
 __Example:__ Finding the arithmetic mode of an array of values:
 
-```javascript
+```js
 r.expr([1,2,2,2,3,3]).group(r.row).count().ungroup().orderBy('reduction').nth(-1)('group').run(conn, callback)
 ```
 

--- a/api/javascript/control-structures/branch.md
+++ b/api/javascript/control-structures/branch.md
@@ -27,7 +27,7 @@ The `branch` command takes 2n+1 arguments: pairs of conditional expressions and 
 
 You may call `branch` infix style on the first test. (See the second example for an illustration.)
 
-```
+```js
 r.branch(test1, val1, test2, val2, elseval)
 ```
 

--- a/api/javascript/selecting-data/between.md
+++ b/api/javascript/selecting-data/between.md
@@ -29,7 +29,9 @@ You may also use the special constants `r.minval` and `r.maxval` for boundaries,
 
 If you use arrays as indexes (compound indexes), they will be sorted using [lexicographical order][lo]. Take the following range as an example:
 
-	[[1, "c"] ... [5, "e"]]
+```text
+[[1, "c"] ... [5, "e"]]
+```
 
 This range includes all compound keys:
 

--- a/api/javascript/writing-data/update.md
+++ b/api/javascript/writing-data/update.md
@@ -120,7 +120,7 @@ r.table("posts").get(1).update({
 
 If you forget to specify the `nonAtomic` flag, you will get a `ReqlRuntimeError`:
 
-```
+```text
 ReqlRuntimeError: Could not prove function deterministic.  Maybe you want to use the non_atomic flag? 
 ```
 


### PR DESCRIPTION
This commit standardises the JavaScript code examples to make them
easier to parse using automated tools.

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
