### PR TITLE
Use camelCase for get_all / getAll

### DIFF
--- a/api/javascript/selecting-data/get_all.md
+++ b/api/javascript/selecting-data/get_all.md
@@ -35,7 +35,7 @@ __Example:__ Without an index argument, we default to the primary index. While `
 r.table('dc').getAll('superman').run(conn, callback)
 ```
 
-__Example:__ You can get multiple documents in a single call to `get_all`.
+__Example:__ You can get multiple documents in a single call to `getAll`.
 
 ```js
 r.table('dc').getAll('superman', 'ant man').run(conn, callback)


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Use getAll instead of get_all as per the rest of the javascript documentation
