### PR TITLE
Fix typos in "Accessing nested fields"

### DIFF
--- a/1-reql-language/nested-fields/java.md
+++ b/1-reql-language/nested-fields/java.md
@@ -171,7 +171,7 @@ r.table("users").get(10001).pluck(
 }
 ```
 
-Be aware this behavior holds true when retrieving data from lists, too. If you extracted `subject` from `notes` above and Bob had 10 notes, 7 of which contained no `subject` field,  you would still get a list of 10 objects: 7 of them would be `{subject: <text>}` and 3 of them would be empty, i.e., `{ }`.
+Be aware this behavior holds true when retrieving data from lists, too. If you extracted `subject` from `notes` above and Bob had 10 notes, 3 of which contained no `subject` field,  you would still get a list of 10 objects: 7 of them would be `{subject: <text>}` and 3 of them would be empty, i.e., `{ }`.
 
 Also, another caveat: the nested field syntax doesn't guarantee identical schemas between documents that it returns. It's possible to describe a path that matches objects that have different schema, as seen in this simple example.
 

--- a/1-reql-language/nested-fields/javascript.md
+++ b/1-reql-language/nested-fields/javascript.md
@@ -153,7 +153,7 @@ If you ask for a nested field that doesn't exist, you will get an empty object o
 }
 ```
 
-Be aware this behavior holds true when retrieving data from lists, too. If you extracted `subject` from `notes` above and Bob had 10 notes, 7 of which contained no `subject` field,  you would still get a list of 10 objects: 7 of them would be `{subject: <text>}` and 3 of them would be empty, i.e., `{ }`.
+Be aware this behavior holds true when retrieving data from lists, too. If you extracted `subject` from `notes` above and Bob had 10 notes, 3 of which contained no `subject` field,  you would still get a list of 10 objects: 7 of them would be `{subject: <text>}` and 3 of them would be empty, i.e., `{ }`.
 
 Also, another caveat: the nested field syntax doesn't guarantee identical schemas between documents that it returns. It's possible to describe a path that matches objects that have different schema, as seen in this simple example.
 

--- a/1-reql-language/nested-fields/javascript.md
+++ b/1-reql-language/nested-fields/javascript.md
@@ -100,7 +100,7 @@ Or, Bob's work phone and Skype handle:
 
 ```js
 > r.table('users').get(10001).pluck(
-	{contact: [{phone: 'work', im: 'skype'}]}
+	{contact: {phone: 'work', im: 'skype'}}
 ).run(conn, callback)
 // result passed to callback
 {
@@ -140,7 +140,7 @@ If you ask for a nested field that doesn't exist, you will get an empty object o
 
 ```js
 > r.table('users').get(10001).pluck(
-	{contact: [{phone: 'work', im: 'msn'}]}
+	{contact: {phone: 'work', im: 'msn'}}
 ).run(conn, callback)
 // result passed to callback
 {
@@ -153,7 +153,7 @@ If you ask for a nested field that doesn't exist, you will get an empty object o
 }
 ```
 
-Be aware this behavior holds true when retrieving data from lists, too. If you extracted `subject` from `notes` above and Bob had 10 notes, 3 of which contained no `subject` field,  you would still get a list of 10 objects: 7 of them would be `{subject: <text>}` and 3 of them would be empty, i.e., `{ }`.
+Be aware this behavior holds true when retrieving data from lists, too. If you extracted `subject` from `notes` above and Bob had 10 notes, 3 of which contained no `subject` field, you would still get a list of 10 objects: 7 of them would be `{subject: <text>}` and 3 of them would be empty, i.e., `{ }`.
 
 Also, another caveat: the nested field syntax doesn't guarantee identical schemas between documents that it returns. It's possible to describe a path that matches objects that have different schema, as seen in this simple example.
 

--- a/1-reql-language/nested-fields/python.md
+++ b/1-reql-language/nested-fields/python.md
@@ -153,7 +153,7 @@ If you ask for a nested field that doesn't exist, you will get an empty object o
 }
 ```
 
-Be aware this behavior holds true when retrieving data from lists, too. If you extracted `subject` from `notes` above and Bob had 10 notes, 7 of which contained no `subject` field,  you would still get a list of 10 objects: 7 of them would be `{subject: <text>}` and 3 of them would be empty, i.e., `{ }`.
+Be aware this behavior holds true when retrieving data from lists, too. If you extracted `subject` from `notes` above and Bob had 10 notes, 3 of which contained no `subject` field,  you would still get a list of 10 objects: 7 of them would be `{subject: <text>}` and 3 of them would be empty, i.e., `{ }`.
 
 Also, another caveat: the nested field syntax doesn't guarantee identical schemas between documents that it returns. It's possible to describe a path that matches objects that have different schema, as seen in this simple example.
 

--- a/1-reql-language/nested-fields/ruby.md
+++ b/1-reql-language/nested-fields/ruby.md
@@ -153,7 +153,7 @@ If you ask for a nested field that doesn't exist, you will get an empty object o
 }
 ```
 
-Be aware this behavior holds true when retrieving data from lists, too. If you extracted `subject` from `notes` above and Bob had 10 notes, 7 of which contained no `subject` field,  you would still get a list of 10 objects: 7 of them would be `{subject => <text>}` and 3 of them would be empty, i.e., `{ }`.
+Be aware this behavior holds true when retrieving data from lists, too. If you extracted `subject` from `notes` above and Bob had 10 notes, 3 of which contained no `subject` field,  you would still get a list of 10 objects: 7 of them would be `{subject => <text>}` and 3 of them would be empty, i.e., `{ }`.
 
 Also, another caveat: the nested field syntax doesn't guarantee identical schemas between documents that it returns. It's possible to describe a path that matches objects that have different schema, as seen in this simple example.
 


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
The "Accessing nested fields" docs seemed to have some (minor) typos that caused the examples to not make sense. Additionally, removing the arrays from some of the pluck commands also seems to better match ES6's destructuring syntax. Have only tested, and so updated, the JS examples but if the other language examples should match I can add another commit.

Thanks rethinkdb team, cool product!
