### PR TITLE
add getting started documentation for go driver

### DIFF
--- a/0-getting-started/drivers/go.md
+++ b/0-getting-started/drivers/go.md
@@ -1,0 +1,64 @@
+---
+layout: documentation
+title: Installing the Go driver
+title_image: /assets/images/docs/driver-languages/go.png
+docs_active: install-drivers
+permalink: docs/install-drivers/go/
+---
+{% include docs/install-driver-docs-header.md %}
+
+# Installation #
+
+Install the driver with `go get`:
+
+```bash
+$ go get gopkg.in/rethinkdb/rethinkdb-go.v5
+```
+
+# Usage #
+
+You can use the drivers from Go like this:
+
+```go
+package rethinkdb_test
+
+import (
+	"fmt"
+	"log"
+
+	r "gopkg.in/rethinkdb/rethinkdb-go.v5"
+)
+
+func Example() {
+	session, err := r.Connect(r.ConnectOpts{
+		Address: url, // endpoint without http
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	res, err := r.Expr("Hello World").Run(session)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	var response string
+	err = res.One(&response)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	fmt.Println(response)
+
+	// Output:
+	// Hello World
+}
+```
+
+To view the full documentation check out [GoDoc](https://godoc.org/github.com/rethinkdb/rethinkdb-go).
+
+# Next steps #
+
+{% infobox %}
+Move on to the [ten-minute guide](/docs/guide/javascript/) and learn how to use RethinkDB.
+{% endinfobox %}

--- a/0-getting-started/drivers/go.md
+++ b/0-getting-started/drivers/go.md
@@ -56,9 +56,3 @@ func Example() {
 ```
 
 To view the full documentation check out [GoDoc](https://godoc.org/github.com/rethinkdb/rethinkdb-go).
-
-# Next steps #
-
-{% infobox %}
-Move on to the [ten-minute guide](/docs/guide/javascript/) and learn how to use RethinkDB.
-{% endinfobox %}

--- a/0-getting-started/drivers/index.md
+++ b/0-getting-started/drivers/index.md
@@ -34,6 +34,12 @@ alias: docs/guides/drivers/
                     <p class="name">Java</p>
                 </a>
             </li>
+            <li>
+                <a href="go/">
+                    <img src="/assets/images/docs/driver-languages/go.png" />
+                    <p class="name">Go</p>
+                </a>
+            </li>
         </ul>
     </section>
     
@@ -93,12 +99,6 @@ alias: docs/guides/drivers/
                 <a href="https://github.com/kureikain/relang">
                     <img src="/assets/images/docs/driver-languages/erlang.png" />
                     <p class="name">Erlang</p>
-                </a>
-            </li>
-            <li>
-                <a href="https://github.com/dancannon/gorethink">
-                    <img src="/assets/images/docs/driver-languages/go.png" />
-                    <p class="name">Go</p>
                 </a>
             </li>
             <li>
@@ -207,7 +207,7 @@ __Thanks to all our amazing driver contributors!__
 - [@bchavez](https://github.com/bchavez) (C#/.NET): [https://github.com/bchavez/RethinkDb.Driver](https://github.com/bchavez/RethinkDb.Driver)
 - [@billysometimes](https://github.com/billysometimes) (Dart): <https://github.com/billysometimes/rethinkdb>
 - [@brandonhamilton](https://github.com/brandonhamilton) (Delphi): <https://github.com/brandonhamilton/rethinkdb-delphi>
-- [@dancannon](https://github.com/dancannon) (Go): <https://github.com/dancannon/gorethink>
+- [@dancannon](https://github.com/dancannon) (Go): <https://github.com/rethinkdb/rethinkdb-go>
 - [@danielmewes](https://github.com/danielmewes) (PHP): <https://github.com/danielmewes/php-rql>
 - [@dkhenry](https://github.com/dkhenry) (Java): <https://github.com/dkhenry/rethinkjava>
 - [@dparnell](https://github.com/dparnell) (Objective-C): <https://github.com/dparnell/rethink-db-client>


### PR DESCRIPTION
This PR updates and adds getting started documentation for the newly official Go driver. It is still missing the ten minute guide, but partially fixes #1226