### PR TITLE
union: fix misleading description of interleave when a function

### DIFF
--- a/api/java/transformations/union.md
+++ b/api/java/transformations/union.md
@@ -26,7 +26,7 @@ The `interleave` [optArg](/api/java/optarg) controls how the sequences will be m
 * `true`: results will be mixed together; this is the fastest setting, but ordering of elements is not guaranteed. (This is the default.)
 * `false`: input sequences will be appended to one another, left to right.
 * `"field_name"`: a string will be taken as the name of a field to perform a merge-sort on. The input sequences must be ordered _before_ being passed to `union`.
-* function: the `interleave` optArg can take a function whose argument is the current row, and whose return value is a string to take as a field name, as with the `"field_name"` setting described above.
+* function: the `interleave` optArg can take a function whose argument is the current row, and whose return value is a value to perform a merge-sort on.
 
 __Example:__ Construct a stream of all heroes.
 

--- a/api/javascript/transformations/union.md
+++ b/api/javascript/transformations/union.md
@@ -26,7 +26,7 @@ The optional `interleave` argument controls how the sequences will be merged:
 * `true`: results will be mixed together; this is the fastest setting, but ordering of elements is not guaranteed. (This is the default.)
 * `false`: input sequences will be appended to one another, left to right.
 * `"field_name"`: a string will be taken as the name of a field to perform a merge-sort on. The input sequences must be ordered _before_ being passed to `union`.
-* function: the `interleave` argument can take a function whose argument is the current row, and whose return value is a string to take as a field name, as with the `"field_name"` setting described above.
+* function: the `interleave` argument can take a function whose argument is the current row, and whose return value is a value to perform a merge-sort on.
 
 __Example:__ Construct a stream of all heroes.
 

--- a/api/python/transformations/union.md
+++ b/api/python/transformations/union.md
@@ -23,7 +23,7 @@ The optional `interleave` argument controls how the sequences will be merged:
 * `True`: results will be mixed together; this is the fastest setting, but ordering of elements is not guaranteed. (This is the default.)
 * `False`: input sequences will be appended to one another, left to right.
 * `"field_name"`: a string will be taken as the name of a field to perform a merge-sort on. The input sequences must be ordered _before_ being passed to `union`.
-* function: the `interleave` argument can take a function whose argument is the current row, and whose return value is a string to take as a field name, as with the `"field_name"` setting described above.
+* function: the `interleave` argument can take a function whose argument is the current row, and whose return value is a value to perform a merge-sort on.
 
 __Example:__ Construct a stream of all heroes.
 

--- a/api/ruby/transformations/union.md
+++ b/api/ruby/transformations/union.md
@@ -23,7 +23,7 @@ The optional `interleave` argument controls how the sequences will be merged:
 * `true`: results will be mixed together; this is the fastest setting, but ordering of elements is not guaranteed. (This is the default.)
 * `false`: input sequences will be appended to one another, left to right.
 * `"field_name"`: a string will be taken as the name of a field to perform a merge-sort on. The input sequences must be ordered _before_ being passed to `union`.
-* function: the `interleave` argument can take a function whose argument is the current row, and whose return value is a string to take as a field name, as with the `"field_name"` setting described above.
+* function: the `interleave` argument can take a function whose argument is the current row, and whose return value is a value to perform a merge-sort on.
 
 __Example:__ Construct a stream of all heroes.
 


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

Closes #1231 

Corrects documentation for `union` `interleave` argument, which uses the return value to sort rows. The documentation currently incorrectly states that the return value should be _"a string to take as a field name"_.

See the [rethinkdb tests](https://github.com/rethinkdb/rethinkdb/blob/98fd78409095a25b04dcaf0eadd6719f381a7d7e/test/rql_test/src/transform/unordered_map.yaml#L34) for examples of this in action.
