### PR TITLE
use RethinkDB python driver >=2.4.0 import method

### DIFF
--- a/0-getting-started/drivers/python.md
+++ b/0-getting-started/drivers/python.md
@@ -25,7 +25,8 @@ You can use the drivers from Python like this:
 
 ```bash
 $ python
-import rethinkdb as r
+from rethinkdb import RethinkDB
+r = RethinkDB()
 r.connect('localhost', 28015).repl()
 r.db('test').table_create('tv_shows').run()
 r.table('tv_shows').insert({ 'name': 'Star Trek TNG' }).run()

--- a/1-reql-language/asynchronous.md
+++ b/1-reql-language/asynchronous.md
@@ -359,11 +359,12 @@ The RethinkDB Python driver integrates with both the [Tornado web framework][tor
 Before `connect`, use the `set_loop_type("tornado")` command to set RethinkDB to use asynchronous event loops compatible with Tornado.
 
 ```py
-import rethinkdb as r
+from rethinkdb import RethinkDB
 from tornado import ioloop, gen
 from tornado.concurrent import Future, chain_future
 import functools
 
+r = RethinkDB()
 r.set_loop_type("tornado")
 connection = r.connect(host='localhost', port=28015)
 ```
@@ -543,10 +544,11 @@ Here, we listen for changes on multiple tables at once.  We simultaneously write
 Before `connect`, use the `set_loop_type("twisted")` command to set RethinkDB to use asynchronous event loops compatible with the Twisted reactor.
  
 ```py
-import rethinkdb as r
+from rethinkdb import RethinkDB
 from twisted.internet import reactor, defer
 from twisted.internet.defer import inlineCallbacks, returnValue
 
+r = RethinkDB()
 r.set_loop_type('twisted')
 connection = r.connect(host='localhost', port=28015)
 ```

--- a/1-reql-language/guide/python.md
+++ b/1-reql-language/guide/python.md
@@ -46,13 +46,14 @@ First, start a Python shell:
 $ python
 ```
 
-Then, import the RethinkDB driver:
+Then, import the RethinkDB driver and create a RethinkDB object:
 
 ```python
-import rethinkdb as r
+from rethinkdb import RethinkDB
+r = RethinkDB()
 ```
 
-You can now access RethinkDB commands through the `r` module.
+You can now access RethinkDB commands through the `r` object.
 
 # Open a connection #
 

--- a/1-reql-language/introduction-to-reql.md
+++ b/1-reql-language/introduction-to-reql.md
@@ -46,8 +46,9 @@ You start using ReQL in your program similarly to how you'd use other
 databases:
 
 ```python
-import rethinkdb as r  # import the RethinkDB package
-conn = r.connect()       # connect to the server on localhost and default port
+from rethinkdb import RethinkDB # import the RethinkDB package
+r = RethinkDB()                 # create a RethinkDB object
+conn = r.connect()              # connect to the server on localhost and default port
 ```
 
 But this is where the similarity ends. Instead of constructing strings

--- a/3-reql-practice/tutorials/superheroes.md
+++ b/3-reql-practice/tutorials/superheroes.md
@@ -21,7 +21,8 @@ instance. We will assume that RethinkDB is running on the same server and on
 the default port (you can change the parameters passed to `connect`): 
 
 ```python
-> import rethinkdb as r
+> from rethinkdb import RethinkDB
+> r = RethinkDB()
 > # connect and make the connection available to subsequent commands 
 > r.connect('localhost', 28015).repl()
 > print r.db_list().run()

--- a/4-admin/administration-tools.md
+++ b/4-admin/administration-tools.md
@@ -33,7 +33,8 @@ These examples use Python, but there's equivalent functionality in Ruby, and any
 Load `python` (or [ipython](http://ipython.org)) and set up a connection to your database:
 
 ```py
-import rethinkdb as r
+from rethinkdb import RethinkDB
+r = RethinkDB()
 r.connect('localhost', 28015).repl()
 ```
 
@@ -78,7 +79,8 @@ The Data Explorer in the web administration UI is itself a JavaScript REPL, with
 By using ReQL with a language like Python, it becomes easy to script administrative and configuration tasks with RethinkDB. If you have complex table configurations that might need to be repeated for new tables or tweaked for the whole database, you can store them in a script.
 
 ```py
-import rethinkdb as r
+from rethinkdb import RethinkDB
+r = RethinkDB()
 conn = r.connect('localhost', 28015)
 
 # Configure the entire database

--- a/7-developing/rabbitmq/python.md
+++ b/7-developing/rabbitmq/python.md
@@ -40,11 +40,11 @@ and pushes them to RabbitMQ.
 First we'll need to set up the connection to the RethinkDB server:
 
 ```python
-
-import rethinkdb as r
+from rethinkdb import RethinkDB
 import pika
 import json
 
+r = RethinkDB()
 rethink_conn = r.connect(host='localhost', port=28015)
 ```
 

--- a/api/python/accessing-rql/r.md
+++ b/api/python/accessing-rql/r.md
@@ -18,6 +18,7 @@ The top-level ReQL namespace.
 __Example:__ Setup your top-level namespace.
 
 ```py
-import rethinkdb as r
+from rethinkdb import RethinkDB
+r = RethinkDB()
 ```
 

--- a/api/python/index.md
+++ b/api/python/index.md
@@ -20,7 +20,8 @@ The top-level ReQL namespace.
 __Example:__ Setup your top-level namespace.
 
 ```py
-import rethinkdb as r
+from rethinkdb import RethinkDB
+r = RethinkDB()
 ```
 
 [Read more about this command &rarr;](r/)


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
Latest RethinkDB python drivers >=2.4.0 are **no longer** using `import rethinkdb as r`.
instead it uses: `from rethinkdb import RethinkDB`
then: `r = RethinkDB()`