### PR TITLE
Add notification about version 5 UUID

### DIFF
--- a/api/java/control-structures/uuid.md
+++ b/api/java/control-structures/uuid.md
@@ -22,6 +22,10 @@ RethinkDB's UUIDs are standards-compliant. Without the optional argument, a vers
 
 [uu]: https://en.wikipedia.org/wiki/Universally_unique_identifier
 
+{% infobox %} 
+Please take into consideration when you generating version 5 UUIDs can’t be considered guaranteed unique if they’re computing based on user data because they use SHA-1 algorithm.
+{% endinfobox %}
+
 __Example:__ Generate a UUID.
 
 ```java

--- a/api/javascript/control-structures/uuid.md
+++ b/api/javascript/control-structures/uuid.md
@@ -22,6 +22,10 @@ RethinkDB's UUIDs are standards-compliant. Without the optional argument, a vers
 
 [uu]: https://en.wikipedia.org/wiki/Universally_unique_identifier
 
+{% infobox %} 
+Please take into consideration when you generating version 5 UUIDs can’t be considered guaranteed unique if they’re computing based on user data because they use SHA-1 algorithm.
+{% endinfobox %}
+
 __Example:__ Generate a UUID.
 
 ```js

--- a/api/python/control-structures/uuid.md
+++ b/api/python/control-structures/uuid.md
@@ -19,6 +19,10 @@ RethinkDB's UUIDs are standards-compliant. Without the optional argument, a vers
 
 [uu]: https://en.wikipedia.org/wiki/Universally_unique_identifier
 
+{% infobox %} 
+Please take into consideration when you generating version 5 UUIDs can’t be considered guaranteed unique if they’re computing based on user data because they use SHA-1 algorithm.
+{% endinfobox %}
+
 __Example:__ Generate a UUID.
 
 ```py

--- a/api/ruby/control-structures/uuid.md
+++ b/api/ruby/control-structures/uuid.md
@@ -19,6 +19,10 @@ RethinkDB's UUIDs are standards-compliant. Without the optional argument, a vers
 
 [uu]: https://en.wikipedia.org/wiki/Universally_unique_identifier
 
+{% infobox %} 
+Please take into consideration when you generating version 5 UUIDs can’t be considered guaranteed unique if they’re computing based on user data because they use SHA-1 algorithm.
+{% endinfobox %}
+
 __Example:__ Generate a UUID.
 
 ```rb


### PR DESCRIPTION
### Description
Version 5 UUIDs can’t be considered guaranteed unique if they’re computing based on user data, because they use SHA-1. This should be mentioned in the docs.
