### PR TITLE
Fix links on cookbook index page

### DIFF
--- a/3-reql-practice/cookbook/index.md
+++ b/3-reql-practice/cookbook/index.md
@@ -7,13 +7,13 @@ permalink: docs/cookbook/
 You can find three cookbooks for the three official drivers. The recipes come from the most
 frequently asked questions.
 
-- [JavaScript](javascript/)
-- [Python](python/)
-- [Ruby](ruby/)
+- [JavaScript](/docs/cookbook/javascript/)
+- [Python](/docs/cookbook/python/)
+- [Ruby](/docs/cookbook/ruby/)
 
-All of the cookbooks are pretty similar, but each may contain additional recipes specific to its language. 
+All of the cookbooks are pretty similar, but each may contain additional recipes specific to its language.
 
-__Looking for another language?__ 
+__Looking for another language?__
 So far, we've only created cookbooks for the three official RethinkDB drivers.
 We'll eventually create ones for our community-supported drivers as well, but
 if you'd like to help us move that process along, contact us at <a


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description

The links to the language-specific cookbooks on the cookbook index page are broken. The PR fixes them. 