### PR TITLE
Try fixing related_commands parsing in index_wait.md

### DIFF
--- a/api/java/manipulating-tables/index_wait.md
+++ b/api/java/manipulating-tables/index_wait.md
@@ -5,7 +5,6 @@ permalink: api/java/index_wait/
 command: indexWait
 related_commands:
     indexStatus: index_status/
-
 ---
 
 # Command syntax #

--- a/api/javascript/manipulating-tables/index_wait.md
+++ b/api/javascript/manipulating-tables/index_wait.md
@@ -8,7 +8,6 @@ io:
         - array
 related_commands:
     indexStatus: index_status/
-
 ---
 
 # Command syntax #


### PR DESCRIPTION
Removes blank line after YAML.  The docs were properly generated
for Python and Ruby, but not Java and JavaScript.

- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/
