### PR TITLE
correct result for bit_not examples

### DIFF
--- a/api/java/math-and-logic/bit_not.md
+++ b/api/java/math-and-logic/bit_not.md
@@ -27,5 +27,5 @@ __Example:__
 r.expr(7).bitNot().run(conn);
 
 // Result:
-8
+-8
 ```

--- a/api/javascript/math-and-logic/bit_not.md
+++ b/api/javascript/math-and-logic/bit_not.md
@@ -30,5 +30,5 @@ __Example:__
 r.expr(7).bitNot().run(conn);
 
 // Result:
-8
+-8
 ```

--- a/api/python/math-and-logic/bit_not.md
+++ b/api/python/math-and-logic/bit_not.md
@@ -27,5 +27,5 @@ __Example:__
 r.expr(7).bitNot().run(conn)
 
 # Result:
-8
+-8
 ```

--- a/api/ruby/math-and-logic/bit_not.md
+++ b/api/ruby/math-and-logic/bit_not.md
@@ -26,5 +26,5 @@ __Example:__
 ```rb
 > r.expr(7).bitNot().run(conn)
 
-8
+-8
 ```


### PR DESCRIPTION
- [x ] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
correct results for bit_not examples
