### PR TITLE
Adjusted documentation of tableList command (Java)

### DIFF
--- a/api/java/manipulating-tables/table_list.md
+++ b/api/java/manipulating-tables/table_list.md
@@ -11,16 +11,19 @@ related_commands:
 # Command syntax #
 
 {% apibody %}
-db.tableList() &rarr; array
+db.tableList() &rarr; TableList
 {% endapibody %}
 
 # Description #
 
 List all table names in a database. The result is a list of strings.
 
-__Example:__ List all tables of the 'test' database.
+__Example:__ List all tables of the 'test' (`DEFAULT_DB_NAME`) database.
 
 ```java
-r.db("test").tableList().run(conn);
-```
+List<?> tableList = r.db(DEFAULT_DB_NAME).tableList().run(connection, ArrayList.class).single();
 
+if (tableList != null) {
+    tableList.forEach(System.out::println);
+}
+```


### PR DESCRIPTION
* provided the correct return type
* extended the example

**Reason for the change**
I tried to simply get the list of table names in a database and the current documentation is not helpful in that regard. The specified return type is wrong and the array with table names had to be extracted from the `Result<Object>`.

**Description**
I corrected the return type and added a useful example that shows how to really get the table names.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)