### PR TITLE
Adjusted documentation of dbList command (Java)

### DIFF
--- a/api/java/manipulating-databases/db_list.md
+++ b/api/java/manipulating-databases/db_list.md
@@ -12,7 +12,7 @@ related_commands:
 # Command syntax #
 
 {% apibody %}
-r.dbList() &rarr; array
+r.dbList() &rarr; DbList
 {% endapibody %}
 
 # Description #
@@ -22,5 +22,9 @@ List all database names in the cluster. The result is a list of strings.
 __Example:__ List all databases.
 
 ```java
-r.dbList().run(conn);
+List<?> dbList = r.dbList().run(connection, ArrayList.class).single();
+
+if (dbList != null) {
+    dbList.forEach(System.out::println);
+}
 ```


### PR DESCRIPTION
* provided the correct return type
* extended the example

**Reason for the change**
I tried to get the list of database names from the server and the current documentation is not helpful in that regard. The specified return type is wrong and the array with database names had to be extracted from the `Result<Object>`.

**Description**
I corrected the return type and added a useful example that shows how to get the database names.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)