### PR TITLE
Fixed documentation as described in issue #1291

### DIFF
--- a/api/java/dates-and-times/time.md
+++ b/api/java/dates-and-times/time.md
@@ -29,13 +29,13 @@ A few restrictions exist on the arguments:
 - `minutes` is an integer.
 - `seconds` is a double. Its value will be rounded to three decimal places
 (millisecond-precision).
-- `timezone` can be `'Z'` (for UTC) or a string with the format `±[hh]:[mm]`.
+- `timezone` can be `"Z"` (for UTC) or a string with the format `±[hh]:[mm]`.
 
 
 __Example:__ Update the birthdate of the user "John" to November 3rd, 1986 UTC.
 
 ```java
 r.table("user").get("John").update(
-    r.hashMap("birthdate", r.time(1986, 11, 3, 'Z'))
+    r.hashMap("birthdate", r.time(1986, 11, 3, "Z"))
 ).run(conn);
 ```


### PR DESCRIPTION
**Reason for the change**
As described in issue #1291 using single quotes leads to an exception.

**Description**
Simply fixed the documentation of the `time` commands `timezone` argument to `String` type.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)