### PR TITLE
Minor change (removed excessive underscore)

### DIFF
--- a/api/java/selecting-data/get.md
+++ b/api/java/selecting-data/get.md
@@ -34,7 +34,7 @@ r.table("heroes").get(3).merge(
 ).run(conn);
 ```
 
-___Example:__ Subscribe to a document's [changefeed](/docs/changefeeds/).
+__Example:__ Subscribe to a document's [changefeed](/docs/changefeeds/).
 
 ```java
 r.table("heroes").get(3).changes().run(conn);


### PR DESCRIPTION
**Reason for the change**
There is an excessive underscore in front of the third 'Example' on [the page of the `get` command](https://rethinkdb.com/api/java/get).

**Description**
Nothing fancy, I just removed the excessive underscore.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)