### PR TITLE
docs: Make related commands use split replace append

### DIFF
--- a/_jekyll/_standalone/_layouts/api-command.html
+++ b/_jekyll/_standalone/_layouts/api-command.html
@@ -25,7 +25,7 @@ body_class: api
                     <h1>Related commands</h1>
                     <ul>
                         {% for related in page.related_commands %}
-                            <li><a href="{{ page.url | replace: page.path, related[1] }}">{{related[0]}}</a></li>
+                            <li><a href="{{ page.url | split: '/' | slice: 0, 3 | join: '/' | append: '/' | append: related[1] }}">{{related[0]}}</a></li>
                         {% endfor %}
                     </ul>
                 </section>


### PR DESCRIPTION
> This change has been **forced**, despite the `.gitignore` created by rake.
> **Code examples** and **References** headers have been removed due to no content needed there.

**Reason for the change**

* Before this change, the `page.path` was attempting to replace `page.url` with the `*.md` extension that doesn't exist.
* Would have used `page.command` but it didn't have cross platform consistency.
* Would have flipped the target (swapping positions of `page.url` and `page.path`), but the related target string isn't complete enough to be auto resolved.

Related commands on documentation are inserted into an existing url, would have rewritten the frontmatter - but that would require changes on a majority of the api pages.

**Description**

The reason for the complex replacement join is due to how liquid identifies and handle strings (and also the order of execution)
* Actual: `split, slice, join(/), append(/), append(related[1])`
* Attempted: `split, slice, append(related[1]), join(/)`
  Placing append before a join breaks the sequence and turns the array of strings into a concatenated string before the join can run resulting in `apijavascriptnext` instead of `api/javascript/next/`

**Checklist**

- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**Side notes**

- The `.gitignore` does not exclude the virtual environment created by rake.
  > Path: `/.venv`
- Gemlock bundler version is at least one minor version behind (2.1.4 -> 2.2.9)
  > Using ruby 2.7.2p137 on GitHub codespace.