### PR TITLE
Ensure related commands are reconstructed correctly (all languages)

### DIFF
--- a/_jekyll/_standalone/_layouts/api-command.html
+++ b/_jekyll/_standalone/_layouts/api-command.html
@@ -25,7 +25,7 @@ body_class: api
                     <h1>Related commands</h1>
                     <ul>
                         {% for related in page.related_commands %}
-                            <li><a href="{{ page.url | replace: page.path, related[1] }}">{{related[0]}}</a></li>
+                            <li><a href="{{ page.url | split: '/' | slice: 0, 3 | join: '/' | append: '/' | append: related[1] }}">{{related[0]}}</a></li>
                         {% endfor %}
                     </ul>
                 </section>

--- a/api/java/accessing-rql/close.md
+++ b/api/java/accessing-rql/close.md
@@ -6,6 +6,7 @@ command: close
 related_commands:
     connect: connect/
     use: use/
+    reconnect: reconnect/
 ---
 
 # Command syntax #

--- a/api/java/dates-and-times/hours.md
+++ b/api/java/dates-and-times/hours.md
@@ -6,6 +6,7 @@ command: hours
 related_commands:
     now: now/
     time: time/
+    inTimezone: in_timezone/
 ---
 
 # Command syntax #

--- a/api/java/dates-and-times/minutes.md
+++ b/api/java/dates-and-times/minutes.md
@@ -6,6 +6,7 @@ command: minutes
 related_commands:
     now: now/
     time: time/
+    inTimezone: in_timezone/
 ---
 
 # Command syntax #

--- a/api/java/dates-and-times/seconds.md
+++ b/api/java/dates-and-times/seconds.md
@@ -6,6 +6,7 @@ command: seconds
 related_commands:
     now: now/
     time: time/
+    inTimezone: in_timezone/
 ---
 
 # Command syntax #

--- a/api/java/dates-and-times/to_epoch_time.md
+++ b/api/java/dates-and-times/to_epoch_time.md
@@ -6,6 +6,7 @@ command: toEpochTime
 related_commands:
     now: now/
     time: time/
+    toIso8601: to_iso8601/
 ---
 
 # Command syntax #

--- a/api/java/document-manipulation/append.md
+++ b/api/java/document-manipulation/append.md
@@ -8,6 +8,7 @@ related_commands:
     insertAt: insert_at/
     deleteAt: delete_at/
     changeAt: change_at/
+    merge: merge/
 ---
 # Command syntax #
 

--- a/api/java/document-manipulation/difference.md
+++ b/api/java/document-manipulation/difference.md
@@ -8,6 +8,7 @@ related_commands:
     setUnion: set_union/
     setIntersection: set_intersection/
     setDifference: set_difference/
+    union: union/
 ---
 
 # Command syntax #

--- a/api/java/document-manipulation/prepend.md
+++ b/api/java/document-manipulation/prepend.md
@@ -8,6 +8,7 @@ related_commands:
     insertAt: insert_at/
     deleteAt: delete_at/
     changeAt: change_at/
+    merge: merge/
 ---
 
 # Command syntax #

--- a/api/java/document-manipulation/set_difference.md
+++ b/api/java/document-manipulation/set_difference.md
@@ -8,6 +8,7 @@ related_commands:
     setInsert: set_insert/
     setUnion: set_union/
     setDifference: set_difference/
+    union: union/
 ---
 
 # Command syntax #

--- a/api/java/document-manipulation/set_insert.md
+++ b/api/java/document-manipulation/set_insert.md
@@ -8,6 +8,7 @@ related_commands:
     setUnion: set_union/
     setIntersection: set_intersection/
     setDifference: set_difference/
+    union: union/
 ---
 
 # Command syntax #

--- a/api/java/document-manipulation/set_intersection.md
+++ b/api/java/document-manipulation/set_intersection.md
@@ -8,6 +8,7 @@ related_commands:
     setInsert: set_insert/
     setUnion: set_union/
     setDifference: set_difference/
+    union: union/
 ---
 
 # Command syntax #

--- a/api/java/document-manipulation/set_union.md
+++ b/api/java/document-manipulation/set_union.md
@@ -8,6 +8,7 @@ related_commands:
     setInsert: set_insert/
     setIntersection: set_intersection/
     setDifference: set_difference/
+    union: union/
 ---
 
 # Command syntax #

--- a/api/java/math-and-logic/not.md
+++ b/api/java/math-and-logic/not.md
@@ -4,7 +4,7 @@ language: Java
 permalink: api/java/not/
 command: not
 related_commands:
-    eq: eq
+    eq: eq/
     ne: ne/
 ---
 

--- a/api/java/selecting-data/between.md
+++ b/api/java/selecting-data/between.md
@@ -9,6 +9,7 @@ alias:
 related_commands:
     get: get/
     getAll: get_all/
+    filter: filter/
 ---
 
 # Command syntax #

--- a/api/java/selecting-data/filter.md
+++ b/api/java/selecting-data/filter.md
@@ -6,7 +6,7 @@ command: filter
 related_commands:
     get: get/
     getAll: get_all/
-
+    between: between/
 ---
 
 # Command syntax #

--- a/api/java/selecting-data/get.md
+++ b/api/java/selecting-data/get.md
@@ -6,6 +6,7 @@ command: get
 related_commands:
     getAll: get_all/
     between: between/
+    filter: filter/
 ---
 
 # Command syntax #

--- a/api/java/selecting-data/get_all.md
+++ b/api/java/selecting-data/get_all.md
@@ -6,6 +6,7 @@ command: getAll
 related_commands:
     get: get/
     between: between/
+    filter: filter/
 ---
 
 # Command syntax #

--- a/api/java/string-manipulation/downcase.md
+++ b/api/java/string-manipulation/downcase.md
@@ -27,7 +27,7 @@ r.expr("Sentence about LaTeX.").downcase().run(conn);
 
 Result:
 
-```
+```java
 "sentence about latex."
 ```
 

--- a/api/java/string-manipulation/match.md
+++ b/api/java/string-manipulation/match.md
@@ -6,6 +6,10 @@ command: match
 io:
     -   - string
         - object
+related_commands:
+    upcase: upcase/
+    downcase: downcase/
+    split: split/
 ---
 
 # Command syntax #

--- a/api/java/string-manipulation/upcase.md
+++ b/api/java/string-manipulation/upcase.md
@@ -27,7 +27,7 @@ r.expr("Sentence about LaTeX.").upcase().run(conn);
 
 Result:
 
-```
+```java
 "SENTENCE ABOUT LATEX."
 ```
 

--- a/api/java/transformations/concat_map.md
+++ b/api/java/transformations/concat_map.md
@@ -5,6 +5,7 @@ permalink: api/java/concat_map/
 command: concatMap
 related_commands:
     map: map/
+    reduce: reduce/
 ---
 
 # Command syntax #

--- a/api/java/transformations/limit.md
+++ b/api/java/transformations/limit.md
@@ -7,6 +7,7 @@ related_commands:
     skip: skip/
     slice: slice/
     nth: nth/
+    orderBy: order_by/
 ---
 
 # Command syntax #

--- a/api/java/transformations/nth.md
+++ b/api/java/transformations/nth.md
@@ -8,6 +8,7 @@ related_commands:
     limit: limit/
     bracket: bracket/
     slice: slice/
+    orderBy: order_by/
 ---
 
 # Command syntax #

--- a/api/java/transformations/skip.md
+++ b/api/java/transformations/skip.md
@@ -7,6 +7,7 @@ related_commands:
     limit: limit/
     slice: slice/
     nth: nth/
+    orderBy: order_by/
 ---
 
 # Command syntax #

--- a/api/java/transformations/with_fields.md
+++ b/api/java/transformations/with_fields.md
@@ -6,6 +6,7 @@ command: withFields
 related_commands:
     pluck: pluck/
     hasFields: has_fields/
+    without: without/
 ---
 
 # Command syntax #

--- a/api/javascript/accessing-rql/close.md
+++ b/api/javascript/accessing-rql/close.md
@@ -9,6 +9,7 @@ io:
 related_commands:
     connect: connect/
     use: use/
+    reconnect: reconnect/
 ---
 
 # Command syntax #

--- a/api/javascript/accessing-rql/event_emitter.md
+++ b/api/javascript/accessing-rql/event_emitter.md
@@ -13,6 +13,7 @@ alias:
 command: "EventEmitter (connection)"
 py: false
 rb: false
+java: false
 io:
     -   - connection
         - undefined

--- a/api/javascript/cursors/ee-cursor.md
+++ b/api/javascript/cursors/ee-cursor.md
@@ -13,6 +13,7 @@ alias:
 command: "EventEmitter (cursor)"
 py: false
 rb: false
+java: false
 io:
     -   - cursor 
         - undefined

--- a/api/javascript/dates-and-times/hours.md
+++ b/api/javascript/dates-and-times/hours.md
@@ -9,6 +9,7 @@ io:
 related_commands:
     now: now/
     time: time/
+    inTimezone: in_timezone/
 ---
 
 # Command syntax #

--- a/api/javascript/dates-and-times/minutes.md
+++ b/api/javascript/dates-and-times/minutes.md
@@ -9,6 +9,7 @@ io:
 related_commands:
     now: now/
     time: time/
+    inTimezone: in_timezone/
 ---
 
 # Command syntax #

--- a/api/javascript/dates-and-times/seconds.md
+++ b/api/javascript/dates-and-times/seconds.md
@@ -9,6 +9,7 @@ io:
 related_commands:
     now: now/
     time: time/
+    inTimezone: in_timezone/
 ---
 
 # Command syntax #

--- a/api/javascript/dates-and-times/to_epoch_time.md
+++ b/api/javascript/dates-and-times/to_epoch_time.md
@@ -9,6 +9,7 @@ io:
 related_commands:
     now: now/
     time: time/
+    toIso8601: to_iso8601/
 ---
 
 # Command syntax #

--- a/api/javascript/document-manipulation/append.md
+++ b/api/javascript/document-manipulation/append.md
@@ -11,6 +11,7 @@ related_commands:
     insertAt: insert_at/
     deleteAt: delete_at/
     changeAt: change_at/
+    merge: merge/
 ---
 # Command syntax #
 

--- a/api/javascript/document-manipulation/difference.md
+++ b/api/javascript/document-manipulation/difference.md
@@ -11,6 +11,7 @@ related_commands:
     setUnion: set_union/
     setIntersection: set_intersection/
     setDifference: set_difference/
+    union: union/
 ---
 
 # Command syntax #

--- a/api/javascript/document-manipulation/prepend.md
+++ b/api/javascript/document-manipulation/prepend.md
@@ -11,6 +11,7 @@ related_commands:
     insertAt: insert_at/
     deleteAt: delete_at/
     changeAt: change_at/
+    merge: merge/
 ---
 
 # Command syntax #

--- a/api/javascript/document-manipulation/set_difference.md
+++ b/api/javascript/document-manipulation/set_difference.md
@@ -11,6 +11,7 @@ related_commands:
     setInsert: set_insert/
     setUnion: set_union/
     setDifference: set_difference/
+    union: union/
 ---
 
 # Command syntax #

--- a/api/javascript/document-manipulation/set_insert.md
+++ b/api/javascript/document-manipulation/set_insert.md
@@ -11,6 +11,7 @@ related_commands:
     setUnion: set_union/
     setIntersection: set_intersection/
     setDifference: set_difference/
+    union: union/
 ---
 
 # Command syntax #

--- a/api/javascript/document-manipulation/set_intersection.md
+++ b/api/javascript/document-manipulation/set_intersection.md
@@ -11,6 +11,7 @@ related_commands:
     setInsert: set_insert/
     setUnion: set_union/
     setDifference: set_difference/
+    union: union/
 ---
 
 # Command syntax #

--- a/api/javascript/document-manipulation/set_union.md
+++ b/api/javascript/document-manipulation/set_union.md
@@ -11,6 +11,7 @@ related_commands:
     setInsert: set_insert/
     setIntersection: set_intersection/
     setDifference: set_difference/
+    union: union/
 ---
 
 # Command syntax #

--- a/api/javascript/math-and-logic/not.md
+++ b/api/javascript/math-and-logic/not.md
@@ -7,7 +7,7 @@ io:
     -   - bool
         - bool
 related_commands:
-    eq: eq
+    eq: eq/
     ne: ne/
 ---
 

--- a/api/javascript/selecting-data/between.md
+++ b/api/javascript/selecting-data/between.md
@@ -12,6 +12,7 @@ io:
 related_commands:
     get: get/
     getAll: get_all/
+    filter: filter/
 ---
 
 # Command syntax #

--- a/api/javascript/selecting-data/filter.md
+++ b/api/javascript/selecting-data/filter.md
@@ -13,7 +13,7 @@ io:
 related_commands:
     get: get/
     getAll: get_all/
-
+    between: between/
 ---
 
 # Command syntax #

--- a/api/javascript/selecting-data/get.md
+++ b/api/javascript/selecting-data/get.md
@@ -9,6 +9,7 @@ io:
 related_commands:
     getAll: get_all/
     between: between/
+    filter: filter/
 ---
 
 # Command syntax #

--- a/api/javascript/selecting-data/get_all.md
+++ b/api/javascript/selecting-data/get_all.md
@@ -9,6 +9,7 @@ io:
 related_commands:
     get: get/
     between: between/
+    filter: filter/
 ---
 
 # Command syntax #

--- a/api/javascript/string-manipulation/match.md
+++ b/api/javascript/string-manipulation/match.md
@@ -6,6 +6,10 @@ command: match
 io:
     -   - string
         - object
+related_commands:
+    upcase: upcase/
+    downcase: downcase/
+    split: split/
 ---
 
 # Command syntax #

--- a/api/javascript/transformations/concat_map.md
+++ b/api/javascript/transformations/concat_map.md
@@ -10,6 +10,7 @@ io:
         - array
 related_commands:
     map: map/
+    reduce: reduce/
 ---
 
 # Command syntax #

--- a/api/javascript/transformations/limit.md
+++ b/api/javascript/transformations/limit.md
@@ -12,6 +12,7 @@ related_commands:
     skip: skip/
     slice: slice/
     nth: nth/
+    orderBy: order_by/
 ---
 
 # Command syntax #

--- a/api/javascript/transformations/nth.md
+++ b/api/javascript/transformations/nth.md
@@ -11,6 +11,7 @@ related_commands:
     limit: limit/
     '() (bracket)': bracket/
     slice: slice/
+    orderBy: order_by/
 ---
 
 # Command syntax #

--- a/api/javascript/transformations/skip.md
+++ b/api/javascript/transformations/skip.md
@@ -12,6 +12,7 @@ related_commands:
     limit: limit/
     slice: slice/
     nth: nth/
+    orderBy: order_by/
 ---
 
 # Command syntax #

--- a/api/javascript/transformations/with_fields.md
+++ b/api/javascript/transformations/with_fields.md
@@ -11,6 +11,7 @@ io:
 related_commands:
     pluck: pluck/
     hasFields: has_fields/
+    without: without/
 ---
 
 # Command syntax #

--- a/api/python/accessing-rql/reconnect.md
+++ b/api/python/accessing-rql/reconnect.md
@@ -7,6 +7,7 @@ related_commands:
     connect: connect/
     use: use/
     repl: repl/
+    close: close/
 ---
 
 # Command syntax #

--- a/api/python/accessing-rql/repl.md
+++ b/api/python/accessing-rql/repl.md
@@ -4,6 +4,7 @@ language: Python
 permalink: api/python/repl/
 command: repl
 js: false
+java: false
 related_commands:
     connect: connect/
     use: use/

--- a/api/python/accessing-rql/run.md
+++ b/api/python/accessing-rql/run.md
@@ -4,8 +4,8 @@ language: Python
 permalink: api/python/run/
 command: run
 related_commands:
-    connect: #connect
-    repl: #repl
+    connect: connect/
+    repl: repl/
 ---
 
 # Command syntax #

--- a/api/python/accessing-rql/set_loop_type.md
+++ b/api/python/accessing-rql/set_loop_type.md
@@ -4,7 +4,9 @@ language: Python
 permalink: api/python/set_loop_type/
 command: set_loop_type
 javascript: false
-ruby: false
+rb: false
+js: false
+java: false
 related_commands:
     connect: connect/
     run: run/

--- a/api/python/control-structures/for_each.md
+++ b/api/python/control-structures/for_each.md
@@ -3,6 +3,8 @@ layout: api-command
 language: Python
 permalink: api/python/for_each/
 command: for_each
+related_commands:
+    map: map/
 ---
 
 # Command syntax #

--- a/api/python/cursors/close-cursor.md
+++ b/api/python/cursors/close-cursor.md
@@ -3,6 +3,10 @@ layout: api-command
 language: Python
 permalink: api/python/close-cursor/
 command: close
+related_commands:
+    next: next/
+    list: to_array/
+    each: each/
 ---
 
 # Command syntax #

--- a/api/python/dates-and-times/seconds.md
+++ b/api/python/dates-and-times/seconds.md
@@ -6,6 +6,7 @@ command: seconds
 related_commands:
     now: now/
     time: time/
+    inTimezone: in_timezone/
 ---
 
 # Command syntax #

--- a/api/python/document-manipulation/append.md
+++ b/api/python/document-manipulation/append.md
@@ -6,6 +6,9 @@ command: append
 related_commands:
     prepend: prepend/
     merge: merge/
+    insert_at: insert_at/
+    delete_at: delete_at/
+    change_at: change_at/
 ---
 
 # Command syntax #

--- a/api/python/document-manipulation/prepend.md
+++ b/api/python/document-manipulation/prepend.md
@@ -6,6 +6,9 @@ command: prepend
 related_commands:
     append: append/
     merge: merge/
+    insert_at: insert_at/
+    delete_at: delete_at/
+    change_at: change_at/
 ---
 
 # Command syntax #

--- a/api/python/document-manipulation/set_insert.md
+++ b/api/python/document-manipulation/set_insert.md
@@ -6,7 +6,6 @@ command: set_insert
 related_commands:
     union: union/
     difference: difference/
-    set_insert: set_insert/
     set_union: set_union/
     set_intersection: set_intersection/
     set_difference: set_difference/

--- a/api/python/manipulating-databases/db_drop.md
+++ b/api/python/manipulating-databases/db_drop.md
@@ -6,6 +6,7 @@ command: db_drop
 related_commands:
     db_create: db_create/
     db_list: db_list/
+    table_create: table_create/
 ---
 
 # Command syntax #

--- a/api/python/math-and-logic/and.md
+++ b/api/python/math-and-logic/and.md
@@ -5,6 +5,8 @@ permalink: api/python/and/
 command: '&, and_'
 related_commands:
     '|, or_': or/
+    '==, eq': eq/
+    '!=, ne': ne/
 ---
 
 # Command syntax #

--- a/api/python/math-and-logic/ge.md
+++ b/api/python/math-and-logic/ge.md
@@ -7,6 +7,8 @@ related_commands:
     '>, gt': gt/
     '<, lt': lt/
     '<=, le': le/
+    '==, eq': eq/
+    '!=, ne': ne/
 ---
 
 # Command syntax #

--- a/api/python/math-and-logic/gt.md
+++ b/api/python/math-and-logic/gt.md
@@ -7,6 +7,8 @@ related_commands:
     '>=, ge': ge/
     '<, lt': lt/
     '<=, le': le/
+    '==, eq': eq/
+    '!=, ne': ne/
 ---
 
 # Command syntax #

--- a/api/python/math-and-logic/le.md
+++ b/api/python/math-and-logic/le.md
@@ -7,6 +7,8 @@ related_commands:
     '>, gt': gt/
     '<, lt': lt/
     '<=, le': le/
+    '==, eq': eq/
+    '!=, ne': ne/
 ---
 
 # Command syntax #

--- a/api/python/math-and-logic/lt.md
+++ b/api/python/math-and-logic/lt.md
@@ -7,6 +7,8 @@ related_commands:
     '>, gt': gt/
     '>=, ge': ge/
     '<=, le': le/
+    '==, eq': eq/
+    '!=, ne': ne/
 ---
 
 # Command syntax #

--- a/api/python/math-and-logic/or.md
+++ b/api/python/math-and-logic/or.md
@@ -5,6 +5,8 @@ permalink: api/python/or/
 command: '|, or_'
 related_commands:
     '&, and_': and/
+    '==, eq': eq/
+    '!=, ne': ne/
 ---
 
 # Command syntax #

--- a/api/python/string-manipulation/match.md
+++ b/api/python/string-manipulation/match.md
@@ -3,6 +3,10 @@ layout: api-command
 language: Python
 permalink: api/python/match/
 command: match
+related_commands:
+    upcase: upcase/
+    downcase: downcase/
+    split: split/
 ---
 
 # Command syntax #

--- a/api/python/transformations/limit.md
+++ b/api/python/transformations/limit.md
@@ -6,7 +6,8 @@ command: limit
 related_commands:
     order_by: order_by/
     skip: skip/
-    '[]': slice/
+    'slice, []': slice/
+    'nth, []': nth/
 ---
 
 # Command syntax #

--- a/api/python/transformations/skip.md
+++ b/api/python/transformations/skip.md
@@ -6,7 +6,8 @@ command: skip
 related_commands:
     order_by: order_by/
     limit: limit/
-    '[]': slice/
+    'slice, []': slice/
+    'nth, []': nth/
 ---
 
 # Command syntax #

--- a/api/ruby/accessing-rql/em_run.md
+++ b/api/ruby/accessing-rql/em_run.md
@@ -3,8 +3,9 @@ layout: api-command
 language: Ruby
 permalink: api/ruby/em_run/
 command: em_run
-javascript: false
-python: false
+js: false
+java: false
+py: false
 related_commands:
     run: run/
 ---

--- a/api/ruby/accessing-rql/repl.md
+++ b/api/ruby/accessing-rql/repl.md
@@ -4,6 +4,7 @@ language: Ruby
 permalink: api/ruby/repl/
 command: repl
 js: false
+java: false
 related_commands:
     connect: connect/
     use: use/

--- a/api/ruby/accessing-rql/use.md
+++ b/api/ruby/accessing-rql/use.md
@@ -7,6 +7,7 @@ related_commands:
     connect: connect/
     repl: repl/
     close: close/
+    reconnect: reconnect/
 ---
 
 # Command syntax #

--- a/api/ruby/control-structures/for_each.md
+++ b/api/ruby/control-structures/for_each.md
@@ -3,6 +3,8 @@ layout: api-command
 language: Ruby
 permalink: api/ruby/for_each/
 command: for_each
+related_commands:
+    map: map/
 ---
 
 # Command syntax #

--- a/api/ruby/cursors/close-cursor.md
+++ b/api/ruby/cursors/close-cursor.md
@@ -3,6 +3,10 @@ layout: api-command
 language: Ruby
 permalink: api/ruby/close-cursor/
 command: close
+related_commands:
+    next: next/
+    to_a: to_array/
+    each: each/
 ---
 
 # Command syntax #

--- a/api/ruby/dates-and-times/day_of_week.md
+++ b/api/ruby/dates-and-times/day_of_week.md
@@ -4,7 +4,8 @@ language: Ruby
 permalink: api/ruby/day_of_week/
 command: day_of_week
 related_commands:
-
+    now: now/
+    time: time/
 ---
 
 # Command syntax #

--- a/api/ruby/document-manipulation/append.md
+++ b/api/ruby/document-manipulation/append.md
@@ -4,6 +4,11 @@ language: Ruby
 permalink: api/ruby/append/
 command: append
 related_commands:
+    prepend: prepend/
+    merge: merge/
+    insert_at: insert_at/
+    delete_at: delete_at/
+    change_at: change_at/
 ---
 
 # Command syntax #

--- a/api/ruby/document-manipulation/difference.md
+++ b/api/ruby/document-manipulation/difference.md
@@ -4,6 +4,11 @@ language: Ruby
 permalink: api/ruby/difference/
 command: difference
 related_commands:
+    union: union/
+    set_insert: set_insert/
+    set_union: set_union/
+    set_intersection: set_intersection/
+    set_difference: set_difference/
 ---
 
 # Command syntax #

--- a/api/ruby/document-manipulation/prepend.md
+++ b/api/ruby/document-manipulation/prepend.md
@@ -4,6 +4,11 @@ language: Ruby
 permalink: api/ruby/prepend/
 command: prepend
 related_commands:
+    append: append/
+    merge: merge/
+    insert_at: insert_at/
+    delete_at: delete_at/
+    change_at: change_at/
 ---
 
 # Command syntax #

--- a/api/ruby/manipulating-databases/db_drop.md
+++ b/api/ruby/manipulating-databases/db_drop.md
@@ -6,6 +6,7 @@ command: db_drop
 related_commands:
     db_create: db_create/
     db_list: db_list/
+    table_create: table_create/
 ---
 
 

--- a/api/ruby/math-and-logic/and.md
+++ b/api/ruby/math-and-logic/and.md
@@ -5,6 +5,8 @@ permalink: api/ruby/and/
 command: '&, and'
 related_commands:
     '|, or': or/
+    '==, eq': eq/
+    '!=, ne': ne/
 ---
 
 # Command syntax #

--- a/api/ruby/math-and-logic/ge.md
+++ b/api/ruby/math-and-logic/ge.md
@@ -7,6 +7,8 @@ related_commands:
     '>, gt': gt/
     '<, lt' : lt/
     '<=, le': le/
+    '==, eq': eq/
+    '!=, ne': ne/
 ---
 
 # Command syntax #

--- a/api/ruby/math-and-logic/gt.md
+++ b/api/ruby/math-and-logic/gt.md
@@ -7,6 +7,8 @@ related_commands:
     '>=, ge': ge/
     '<, lt' : lt/
     '<=, le': le/
+    '==, eq': eq/
+    '!=, ne': ne/
 ---
 
 # Command syntax #

--- a/api/ruby/math-and-logic/le.md
+++ b/api/ruby/math-and-logic/le.md
@@ -7,6 +7,8 @@ related_commands:
     '>, gt': gt/
     '>=, ge': ge/
     '<, lt': lt/
+    '==, eq': eq/
+    '!=, ne': ne/
 ---
 
 # Command syntax #

--- a/api/ruby/math-and-logic/lt.md
+++ b/api/ruby/math-and-logic/lt.md
@@ -7,6 +7,8 @@ related_commands:
     '>, gt': gt/
     '>=, ge': ge/
     '<=, le': le/
+    '==, eq': eq/
+    '!=, ne': ne/
 ---
 
 # Command syntax #

--- a/api/ruby/math-and-logic/or.md
+++ b/api/ruby/math-and-logic/or.md
@@ -5,6 +5,8 @@ permalink: api/ruby/or/
 command: '|, or'
 related_commands:
     '&, and': and/
+    '==, eq': eq/
+    '!=, ne': ne/
 ---
 
 # Command syntax #

--- a/api/ruby/transformations/limit.md
+++ b/api/ruby/transformations/limit.md
@@ -6,7 +6,8 @@ command: limit
 related_commands:
     order_by: order_by/
     skip: skip/
-    '[]': slice/
+    'slice, []': slice/
+    'nth, []': nth/
 ---
 
 # Command syntax #

--- a/api/ruby/transformations/skip.md
+++ b/api/ruby/transformations/skip.md
@@ -6,7 +6,8 @@ command: skip
 related_commands:
     order_by: order_by/
     limit: limit/
-    '[]': slice/
+    'slice, []': slice/
+    'nth, []': nth/
 ---
 
 # Command syntax #


### PR DESCRIPTION
**Reason for the change**

* Before this change, the `page.path` was attempting to replace `page.url` with the `*.md` extension that doesn't exist.
* Along with the 88 file changes to bring method siblings in line with each other as much as possible.

**Description** - direct from #1303

The reason for the complex replacement join is due to how liquid identifies and handle strings (and also the order of execution)
* Actual: `split, slice, join(/), append(/), append(related[1])`
* Attempted: `split, slice, append(related[1]), join(/)`
  Placing append before a join breaks the sequence and turns the array of strings into a concatenated string before the join can run resulting in `apijavascriptnext` instead of `api/javascript/next/`

**Code examples**
No core documentation was changed.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
- [Google Sheet](https://docs.google.com/spreadsheets/d/1MiHKc0NsDydamK38skCuq7C_YiJt6Ex9yPxSVra3_g8/edit?usp=sharing) created for this PR, to determine what needed to be changed without double backing on myself.
  > Language navigator faults / Page mismatch also ended up being tracked on this spreadsheet despite saying they *actively* weren't.

**Side notes**
- Not all pages have the self-reference problem, which leads me to believe it's a problem with caching on the deployment end.
- `span.disabled` for language navigator no longer exists, and I cannot determine when it was removed or if it existed to begin with.