### PR TITLE
Add that hyphens are valid in database names

### DIFF
--- a/api/java/manipulating-databases/db_create.md
+++ b/api/java/manipulating-databases/db_create.md
@@ -29,7 +29,7 @@ If successful, the command returns an object with two fields:
 
 If a database with the same name already exists, the command throws `ReqlRuntimeError`.
 
-Note: Only alphanumeric characters and underscores are valid for the database name.
+Note: Only alphanumeric characters, hyphens and underscores are valid for the database name.
 
 __Example:__ Create a database named 'superheroes'.
 

--- a/api/javascript/manipulating-databases/db_create.md
+++ b/api/javascript/manipulating-databases/db_create.md
@@ -32,7 +32,7 @@ If successful, the command returns an object with two fields:
 
 If a database with the same name already exists, the command throws `ReqlRuntimeError`.
 
-Note: Only alphanumeric characters and underscores are valid for the database name.
+Note: Only alphanumeric characters, hyphens and underscores are valid for the database name.
 
 __Example:__ Create a database named 'superheroes'.
 

--- a/api/python/manipulating-databases/db_create.md
+++ b/api/python/manipulating-databases/db_create.md
@@ -29,7 +29,7 @@ If successful, the command returns an object with two fields:
 
 If a database with the same name already exists, the command throws `ReqlRuntimeError`.
 
-Note: Only alphanumeric characters and underscores are valid for the database name.
+Note: Only alphanumeric characters, hyphens and underscores are valid for the database name.
 
 __Example:__ Create a database named 'superheroes'.
 

--- a/api/ruby/manipulating-databases/db_create.md
+++ b/api/ruby/manipulating-databases/db_create.md
@@ -29,7 +29,7 @@ If successful, the command returns an object with two fields:
 
 If a database with the same name already exists, the command throws `ReqlRuntimeError`.
 
-Note: Only alphanumeric characters and underscores are valid for the database name.
+Note: Only alphanumeric characters, hyphens and underscores are valid for the database name.
 
 __Example:__ Create a database named 'superheroes'.
 


### PR DESCRIPTION
**Reason for the change**
It seems the docs are out of date, that hyphens are allowed in database names (https://github.com/rethinkdb/rethinkdb-python/pull/183).

**Description**
I updated a single sentence in the JavaScript, Python, Ruby and Java docs. (should be clear from the commit)

I updated the sentence to have word order similar to the Web UI error notice given when creating a database with an invalid name, `You can only use alphanumeric characters, hyphens and underscores for a database's name.`.

**Code examples**
NA

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
NA
