### PR TITLE
docs: add s390x

### DIFF
--- a/0-getting-started/install/index.md
+++ b/0-getting-started/install/index.md
@@ -132,9 +132,13 @@ RethinkDB on FreeBSD by testing the build!
 
 ## Other architectures ##
 
-Currently the RethinkDB server only supports x86 and x86\_64 architectures on
-Unix-based platforms, and has experimental ARM support (thanks to the effort of
-[@davidthomas426](http://github.com/davidthomas426)).
+Currently, the RethinkDB server supports x86_64, ARM, and s390x architectures
+on Unix-based platforms and Windows Subsystem for Linux.
+
+Special thanks to the effort of [@davidthomas426](http://github.com/davidthomas426)
+for making the ARM support available. Also, thank you [Open Source Software Developer
+Cloud on LinuxONE](https://developer.ibm.com/articles/get-started-with-ibm-linuxone/)
+for providing the s390x build machines.
 
 Our long-term goal is to port RethinkDB to every widely-used platform. [Get
 involved](/community/) in the development effort and help port RethinkDB to


### PR DESCRIPTION
**Reason for the change**

The s390x architecture is supported by RethinkDB, but it is missing from the docs.

**Description**

This PR adds s390x support and recognizes the help of the `Open Source Software Developer Cloud on LinuxONE`'s support with the build machine.

**Checklist**

- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**

- https://github.com/rethinkdb/rethinkdb/issues/7071