### PR TITLE
Use absolute paths.

### DIFF
--- a/1-reql-language/guide/index.md
+++ b/1-reql-language/guide/index.md
@@ -6,7 +6,7 @@ permalink: docs/guide/
 ---
 Choose your language:
 
-- [JavaScript](javascript/)
-- [Python](python/)
-- [Ruby](ruby/)
-- [Java](java/)
+- [JavaScript](/docs/guide/javascript/)
+- [Python](/docs/guide/python/)
+- [Ruby](/docs/guide/ruby/)
+- [Java](/docs/guide/java/)


### PR DESCRIPTION
See https://github.com/rethinkdb/docs/issues/1345

The page /docs/guide was being accessed, but the links were
relative to /docs/guide/ with the trailing slash.

- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
