### PR TITLE
Update for early Windows 2.4.3 release

### DIFF
--- a/0-getting-started/install/index.md
+++ b/0-getting-started/install/index.md
@@ -39,15 +39,12 @@ alias: install/
                     <p class="name">OS X</p>
                 </a>
             </li>
-
-            <!--
             <li>
                 <a href="windows/">
                     <img src="/assets/images/docs/install-platforms/windows.png" />
                     <p class="name">Windows</p>
                 </a>
             </li>
-            -->
         </ul>
     </section>
     <section class="platform-category">

--- a/0-getting-started/install/windows.md
+++ b/0-getting-started/install/windows.md
@@ -10,12 +10,12 @@ permalink: docs/install/windows/
 # Downloading #
 
 {% infobox %}
-The Windows port of RethinkDB is not available for the {{site.version.full}} version yet. As an alternative, you can use the docker based version.
+The Windows port of RethinkDB is now available early for RethinkDB 2.4.3!  This is the first official 2.4.x Windows release.
 {% endinfobox %}
 
 _Prerequisites:_ We provide native 64-bit binaries for Windows 7 and above. A 64-bit version of Windows is required.
 
-[Download](https://download.rethinkdb.com/repository/raw/windows/rethinkdb-{{site.version.full}}.zip) the ZIP archive and unpack it in a directory of your choice.
+[Download](https://download.rethinkdb.com/repository/raw/windows/rethinkdb-2.4.3.zip) the ZIP archive and unpack it in a directory of your choice.
 
 {% infobox %}
 The Windows port of RethinkDB is a recent addition and hasn't received as much tuning as the Linux and OS X versions yet. Please report any performance issues on [GitHub][gh-issues].


### PR DESCRIPTION
Uncomments the Windows link and makes the page hard-code 2.4.3.

Since the page hardcodes 2.4.3, we'll want to undo that once 2.4.3 is released.

- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
