### PR TITLE
Fix permission issue during installation

### DIFF
--- a/0-getting-started/install/fedora.md
+++ b/0-getting-started/install/fedora.md
@@ -16,7 +16,7 @@ Fedora.
 To install the server, add the RethinkDB yum repository to your list of repositories and install:
 
 ```bash
-sudo cat << EOF > /etc/yum.repos.d/rethinkdb.repo
+cat << EOF | sudo tee -a /etc/yum.repos.d/rethinkdb.repo
 [rethinkdb]
 name=RethinkDB
 enabled=1


### PR DESCRIPTION
**Reason for the change**
sudo cat will run only cat as root, and fail do create the file
**Description**

**Code examples**


**Checklist**
- [x ] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**

